### PR TITLE
Include babel cli and es2015 preset

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -15,6 +15,11 @@
           "targets": {"node": "current"}
         }]
       ]
+    },
+    "production": {
+      "presets": [
+        ["env"]
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint-benchmarks": "cd benchmarks&&run lintFolder",
     "lint-rambda": "run lint f rambda.js",
     "jest": "jest",
-    "prepublish": "BABEL_ENV=production babel modules/ --out-dir lib/"
+    "prepublish": "BABEL_ENV=production babel modules/ --presets babel-preset-es2015 --out-dir lib/"
   },
   "repository": {
     "type": "git",
@@ -44,6 +44,7 @@
     "babel-cli": "^6.26.0",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-env": "^1.6.1",
+    "babel-preset-es2015": "^6.24.1",
     "beautify-benchmark": "^0.2.4",
     "benchmark": "^2.1.3",
     "jest": "^21.0.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "homepage": "https://github.com/selfrefactor/rambda#readme",
   "devDependencies": {
+    "babel-cli": "^6.26.0",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-env": "^1.6.1",
     "beautify-benchmark": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint-benchmarks": "cd benchmarks&&run lintFolder",
     "lint-rambda": "run lint f rambda.js",
     "jest": "jest",
-    "prepublish": "BABEL_ENV=production babel modules/ --presets babel-preset-es2015 --out-dir lib/"
+    "prepublish": "BABEL_ENV=production babel modules/ --out-dir lib/"
   },
   "repository": {
     "type": "git",
@@ -44,7 +44,6 @@
     "babel-cli": "^6.26.0",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-env": "^1.6.1",
-    "babel-preset-es2015": "^6.24.1",
     "beautify-benchmark": "^0.2.4",
     "benchmark": "^2.1.3",
     "jest": "^21.0.1",


### PR DESCRIPTION
Forgot to include `babel-cli` as dev dependency, hence tests failed.

Possible to release a new npm version ?