### PR TITLE
Fix example for multiply function on docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -659,7 +659,7 @@ R.module(14,3) // => 2
 It returns the result of operation `a*b`.
 
 ```javascript
-R.module(14,3) // => 2
+R.multiply(4,3) // => 12
 ```
 
 #### not


### PR DESCRIPTION
It was using the example from module function