### PR TITLE
Annotate curry calls as #__PURE__

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,7 +7,10 @@
           "modules" : false
         }]
       ],
-      "plugins": ["external-helpers"]
+      "plugins": [
+        "external-helpers",
+        "annotate-pure-calls"
+      ]
     },
     "test": {
       "presets": [

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/rambda.cjs.js",
   "module": "./dist/rambda.esm.js",
   "typings": "./index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "dev": "jest __tests__/logic/compose.js --watch",
     "test": "jest __tests__",
@@ -50,6 +51,7 @@
   ],
   "devDependencies": {
     "babel-cli": "^6.26.0",
+    "babel-plugin-annotate-pure-calls": "^0.2.2",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-env": "^1.6.1",
     "beautify-benchmark": "^0.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,6 +519,12 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-annotate-pure-calls@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-annotate-pure-calls/-/babel-plugin-annotate-pure-calls-0.2.2.tgz#a0d8c27361db4a518d925a7202f8854382b17594"
+  dependencies:
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+
 babel-plugin-check-es2015-constants@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
@@ -555,6 +561,10 @@ babel-plugin-jest-hoist@^23.0.0-alpha.4:
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
 
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"


### PR DESCRIPTION
This should make `pathOr` tree-shakeable as its a result of a `curry` call that cannot be tree-shaken easily (as you know), by annotating it with `#__PURE__` (with the help of the babel plugin) we give a hint to uglifyJS that it can be removed if the call's result stay unused