### PR TITLE
fix(typing): fix incorrect inference

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -401,8 +401,7 @@ declare namespace R {
      * Returns the first element in a list.
      * In some libraries this function is named `first`.
      */
-    head<T>(list: ReadonlyArray<T>): T | undefined;
-    head(list: string): string;
+    head<T extends Readonly<any> | string>(list: T): T extends string ? string : (T[0] | undefined)
 
     /**
      * A function that does nothing but return the parameter supplied to it. Good as a default

--- a/index.d.ts
+++ b/index.d.ts
@@ -401,7 +401,7 @@ declare namespace R {
      * Returns the first element in a list.
      * In some libraries this function is named `first`.
      */
-    head<T extends Readonly<any> | string>(list: T): T extends string ? string : (T[0] | undefined)
+    head<T extends Readonly<any> | string>(list: T): T extends string ? string : (T[0] | undefined);
 
     /**
      * A function that does nothing but return the parameter supplied to it. Good as a default


### PR DESCRIPTION
```ts
import { head } from 'rambda';

function fixedHead<T extends Readonly<any> | string>(
  list: T,
): T extends string ? string : (T[0] | undefined) {
  return list[0];
}

fixedHead('hi'); // it returns string :-)

const test = [[1, 2], [3, 4]];

const test00 = test.map(head).map(x => x); // x is string :'(
const test01 = test.map(fixedHead).map(x => x); // x is number! :-D
```

Thank you for your effort in this lib :smile: 