### PR TITLE
Fix object check in assocPath

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rambda",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Lightweight faster alternative to Ramda",
   "main": "./dist/rambda.js",
   "module": "./dist/rambda.esm.js",

--- a/src/assocPath.js
+++ b/src/assocPath.js
@@ -1,5 +1,4 @@
 import { _isInteger } from "./internal/_isInteger"
-import { _objectIs } from "./internal/_objectIs"
 import { assoc } from './assoc'
 import { curry } from './curry'
 
@@ -28,7 +27,7 @@ function assocPathFn(list, val, obj){
 
   const index = pathArrValue[0]
   if (pathArrValue.length > 1){
-    const nextObj = !(_objectIs(obj) && obj.hasOwnProperty(index))
+    const nextObj = typeof obj !== "object" || !obj.hasOwnProperty(index)
       ? _isInteger(parseInt(pathArrValue[1], 10)) ? [] : {}
       : obj[index]
     val = assocPathFn(Array.prototype.slice.call(pathArrValue, 1), val, nextObj)

--- a/src/assocPath.spec.js
+++ b/src/assocPath.spec.js
@@ -20,6 +20,16 @@ test('adds a nested key to a non-empty object', () => {
   })
 })
 
+test('adds a nested key to a nested non-empty object - curry case 1', () => {
+  expect(assocPath('b.d', 3)({ a : 1, b: { c : 2 } })).toEqual({
+    a : 1,
+    b : {
+      c : 2,
+      d : 3
+    }
+  })
+})
+
 test('adds a key to a non-empty object - curry case 1', () => {
   expect(assocPath('b', 2)({ a : 1 })).toEqual({
     a : 1,


### PR DESCRIPTION
When implementing `assocPath` I assumed that the `_objectIs` helper checks if the type is an object. As it doesn't, nested objects are overwritten rather than augmented. This PR adds a test case that reproduces the problem and fixes it.