### PR TITLE
removed implemented 'and' method from ramdaMissing.md file

### DIFF
--- a/files/ramdaMissing.md
+++ b/files/ramdaMissing.md
@@ -90,8 +90,6 @@
 
 ### Logic
  
- [and](https://raw.githubusercontent.com/ramda/ramda/master/source/and.js)
- 
  [cond](https://raw.githubusercontent.com/ramda/ramda/master/source/cond.js)
  
  [or](https://raw.githubusercontent.com/ramda/ramda/master/source/or.js)


### PR DESCRIPTION
![Screen Shot 2019-12-06 at 6 32 22 AM](https://user-images.githubusercontent.com/19601060/70320269-45df2d80-17f2-11ea-969f-f4a2b89425c2.png)

**and** method is implemented and it's in master branch. So, basically this PR is updating the ramdaMissing.md file