### PR TITLE
fixing wrong documentation example and REPL links for compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -2921,7 +2921,7 @@ It performs right-to-left function composition.
 
 ```javascript
 const result = R.compose(
-  R.map(x => x * 2),both
+  R.map(x => x * 2),
   R.filter(x => x > 2)
 )([1, 2, 3, 4])
 
@@ -3007,7 +3007,7 @@ export function compose(...fns){
 
 </details>
 
-<a href="https://rambda.now.sh?const%20result%20%3D%20R.compose(%0A%20%20R.map(x%20%3D%3E%20x%20*%202)%2Cboth%0A%20%20R.filter(x%20%3D%3E%20x%20%3E%202)%0A)(%5B1%2C%202%2C%203%2C%204%5D)%0A%0A%2F%2F%20%3D%3E%20%5B6%2C%208%5D">Try in REPL</a>
+<a href="https://rambda.now.sh?const%20result%20%3D%20R.compose(%0A%20%20R.map(x%20%3D%3E%20x%20*%202)%2C%0A%20%20R.filter(x%20%3D%3E%20x%20%3E%202)%0A)(%5B1%2C%202%2C%203%2C%204%5D)%0A%0A%2F%2F%20%3D%3E%20%5B6%2C%208%5D">Try in REPL</a>
 
 ---
 #### complement

--- a/docs/README.md
+++ b/docs/README.md
@@ -3007,7 +3007,7 @@ export function compose(...fns){
 
 </details>
 
-<a href="https://rambda.now.sh?const%20result%20%3D%20R.compose(%0A%20%20R.map(x%20%3D%3E%20x%20*%202)%2Cboth%0A%20%20R.filter(x%20%3D%3E%20x%20%3E%202)%0A)(%5B1%2C%202%2C%203%2C%204%5D)%0A%0A%2F%2F%20%3D%3E%20%5B6%2C%208%5D">Try in REPL</a>
+<a href="https://rambda.now.sh?const%20result%20%3D%20R.compose(%0A%20%20R.map(x%20%3D%3E%20x%20*%202)%2C%0A%20%20R.filter(x%20%3D%3E%20x%20%3E%202)%0A)(%5B1%2C%202%2C%203%2C%204%5D)%0A%0A%2F%2F%20%3D%3E%20%5B6%2C%208%5D">Try in REPL</a>
 
 ---
 #### complement

--- a/docs/README.md
+++ b/docs/README.md
@@ -2921,7 +2921,7 @@ It performs right-to-left function composition.
 
 ```javascript
 const result = R.compose(
-  R.map(x => x * 2),both
+  R.map(x => x * 2),
   R.filter(x => x > 2)
 )([1, 2, 3, 4])
 


### PR DESCRIPTION
in the README.md and docs/README.md are shown 2 wrong examples for compose.

removed the usage of both in the examples and REPL 