### PR TITLE
fix@issue #464 make r.flip work for any arity

### DIFF
--- a/source/curry.js
+++ b/source/curry.js
@@ -1,5 +1,5 @@
 import { curryN } from './curryN'
 
-export function curry(fn, args = []){
+export function curry(fn) {
   return curryN(fn.length, fn)
 }

--- a/source/curry.js
+++ b/source/curry.js
@@ -1,7 +1,5 @@
+import { curryN } from './curryN'
+
 export function curry(fn, args = []){
-  return (..._args) =>
-    (rest => rest.length >= fn.length ? fn(...rest) : curry(fn, rest))([
-      ...args,
-      ..._args,
-    ])
+  return curryN(fn.length, fn)
 }

--- a/source/flip.js
+++ b/source/flip.js
@@ -1,21 +1,29 @@
-function flipExport(fn){
-  return (...input) => {
-    if (input.length === 1){
-      return holder => fn(holder, input[ 0 ])
-    } else if (input.length === 2){
-      return fn(input[ 1 ], input[ 0 ])
-    } else if (input.length === 3){
-      return fn(
-        input[ 1 ], input[ 0 ], input[ 2 ]
-      )
-    } else if (input.length === 4){
-      return fn(
-        input[ 1 ], input[ 0 ], input[ 2 ], input[ 3 ]
-      )
-    }
+import { curryN } from './curryN.js'
 
-    throw new Error('R.flip doesn\'t work with arity > 4')
+function flipExport(fn) {
+  const flipedFn = (...input) => {
+    const missing = fn.length - input.length;
+
+    if (missing <= 0)
+      return fn(input[1], input[0], ...input.slice(2))
+
+    if (input.length === 0)
+      return flipedFn
+
+    if (input.length === 1)
+      return curryN(missing, (...rest) => {
+        const args = [rest[0], input[0], ...rest.slice(1)]
+        return fn(...args)
+      })
+
+    // input.length >= 2
+    return curryN(missing, (...rest) => {
+      const args = [input[1], input[0], ...input.slice(2), ...rest]
+      return fn(...args)
+    })
   }
+
+  return flipedFn
 }
 
 export function flip(fn){

--- a/source/flip.spec.js
+++ b/source/flip.spec.js
@@ -15,40 +15,32 @@ test('function with arity of 2', () => {
 test('function with arity of 3', () => {
   const updateFlipped = flip(update)
 
-  const result = updateFlipped(
-    88, 0, [ 1, 2, 3 ]
-  )
+  const result = updateFlipped(88, 0, [ 1, 2, 3 ])
   const curriedResult = updateFlipped(88, 0)([ 1, 2, 3 ])
   const tripleCurriedResult = updateFlipped(88)(0)([ 1, 2, 3 ])
+
   expect(result).toEqual([ 88, 2, 3 ])
   expect(curriedResult).toEqual([ 88, 2, 3 ])
   expect(tripleCurriedResult).toEqual([ 88, 2, 3 ])
 })
 
 test('function with arity of 4', () => {
-  const testFunction = (
-    a, b, c, d
-  ) => `${ a - b }==${ c - d }`
-  const testFunctionFlipped = flip(testFunction)
+  const testFunction = (a, b, c, d) =>
+    `${a},${b},${c},${d}`
 
-  const result = testFunction(
-    1, 2, 3, 4
-  )
-  const flippedResult = testFunctionFlipped(
-    2, 1, 3, 4
-  )
-  expect(result).toEqual(flippedResult)
-  expect(result).toEqual('-1==-1')
-})
+  const flippedFn = flip(testFunction)
 
-test('function with arity of 5', () => {
-  const testFunction = (
-    a, b, c, d, e
-  ) => `${ a - b }==${ c - d - e }`
-  const testFunctionFlipped = flip(testFunction)
+  const result1 = flippedFn(2)(1)(3)(4)
+  const result2 = flippedFn(2)(1, 3, 4)
+  const result3 = flippedFn(2, 1)(3, 4)
+  const result4 = flippedFn(2, 1, 3)(4)
+  const result5 = flippedFn(2, 1, 3, 4)
 
-  expect(() => testFunctionFlipped(
-    1, 2, 3, 4, 5
-  )).toThrowWithMessage(Error,
-    'R.flip doesn\'t work with arity > 4')
+  const expected = '1,2,3,4'
+
+  expect(result1).toEqual(expected)
+  expect(result2).toEqual(expected)
+  expect(result3).toEqual(expected)
+  expect(result4).toEqual(expected)
+  expect(result5).toEqual(expected)
 })


### PR DESCRIPTION
I've removed the arity 5 test because it's not necessary, but I've made sure to cover all codepaths of `flip` in arity 4 test.

As mentionned in the issue, it's necessary to use `curryN` in `curry` to preserve the `Function.length` property.

Closes #464