### PR TITLE
Improve filter performance

### DIFF
--- a/source/filter.js
+++ b/source/filter.js
@@ -21,17 +21,19 @@ export function filter(predicate, list){
     return filterObject(predicate, list)
   }
 
-  let index = -1
+  let index = 0
   let resIndex = 0
   const len = list.length
   const willReturn = []
 
-  while (++index < len){
+  while (index < len){
     const value = list[ index ]
 
     if (predicate(value, index)){
       willReturn[ resIndex++ ] = value
     }
+
+    index++
   }
 
   return willReturn

--- a/source/filter.js
+++ b/source/filter.js
@@ -22,7 +22,6 @@ export function filter(predicate, list){
   }
 
   let index = 0
-  let resIndex = 0
   const len = list.length
   const willReturn = []
 
@@ -30,7 +29,7 @@ export function filter(predicate, list){
     const value = list[ index ]
 
     if (predicate(value, index)){
-      willReturn[ resIndex++ ] = value
+      willReturn.push(value)
     }
 
     index++


### PR DESCRIPTION
1. push is faster than index assignment on modern js engines (tested with latest chromium, firefox, nodejs v14.3.0)
2. Set initial index to zero. No need variable initialization for engine. And look like some perf penalty for negative values.

Tested with 10k values and all pass predicate.

**Before**
```js
  Rambda:
    14 325 ops/s, ±1.89%   | 8.67% slower
  Ramda:
    15 685 ops/s, ±1.66%   | fastest
  Lodash:
    5 824 ops/s, ±2.31%    | slowest, 62.87% slower
```
**After**
```js
  Rambda:
    16 500 ops/s, ±1.92%   | fastest
  Ramda:
    15 556 ops/s, ±2.28%   | 5.72% slower
  Lodash:
    5 799 ops/s, ±2.00%    | slowest, 64.85% slower
```