### PR TITLE
Improve find performance

### DIFF
--- a/source/find.js
+++ b/source/find.js
@@ -1,5 +1,16 @@
 export function find(predicate, list){
   if (arguments.length === 1) return _list => find(predicate, _list)
 
-  return list.find(predicate)
+  let index = 0
+  const len = list.length
+
+  while (index < len){
+    const value = list[ index ]
+
+    if (predicate(value, index)){
+      return value
+    }
+
+    index++
+  }
 }


### PR DESCRIPTION
Motivation about initial zero index you can find here https://github.com/selfrefactor/rambda/pull/472
Tested with 10k values and false predicate.

**Before**
```js
  Rambda:
    12 109 ops/s, ±2.35%    | slowest, 93.4% slower
  Ramda:
    183 486 ops/s, ±1.26%   | fastest
  Lodash:
    144 319 ops/s, ±0.87%   | 21.35% slower
```

**After**
```js
  Rambda:
    218 888 ops/s, ±0.79%   | fastest
  Ramda:
    204 801 ops/s, ±0.92%   | 6.44% slower
  Lodash:
    141 907 ops/s, ±2.54%   | slowest, 35.17% slower
```
