### PR TITLE
Accessing isArray method is relatively expensive operation

### DIFF
--- a/source/_internals/_isArray.js
+++ b/source/_internals/_isArray.js
@@ -1,0 +1,2 @@
+// extract for optimization
+export const _isArray = Array.isArray

--- a/source/_internals/isFalsy.js
+++ b/source/_internals/isFalsy.js
@@ -1,7 +1,8 @@
+import { _isArray } from './_isArray'
 import { type } from '../type'
 
 export function isFalsy(x){
-  if (Array.isArray(x)){
+  if (_isArray(x)){
     return x.length === 0
   }
   if (type(x) === 'Object'){

--- a/source/_internals/isTruthy.js
+++ b/source/_internals/isTruthy.js
@@ -1,7 +1,8 @@
+import { _isArray } from './_isArray'
 import { type } from '../type'
 
 export function isTruthy(x){
-  if (Array.isArray(x)){
+  if (_isArray(x)){
     return x.length > 0
   }
   if (type(x) === 'Object'){

--- a/source/applySpec.js
+++ b/source/applySpec.js
@@ -1,3 +1,5 @@
+import { _isArray } from './_internals/_isArray'
+
 // recursively traverse the given spec object to find the highest arity function
 function __findHighestArity(spec, max = 0){
   for (const key in spec){
@@ -72,13 +74,13 @@ function __applySpecWithArity(
       )
 
   // handle spec as Array
-  if (Array.isArray(spec)){
+  if (_isArray(spec)){
     const ret = []
     let i = 0
     const l = spec.length
     for (; i < l; i++){
       // handle recursive spec inside array
-      if (typeof spec[ i ] === 'object' || Array.isArray(spec[ i ])){
+      if (typeof spec[ i ] === 'object' || _isArray(spec[ i ])){
         ret[ i ] = __applySpecWithArity(
           spec[ i ], arity, cache
         )

--- a/source/assocPath.js
+++ b/source/assocPath.js
@@ -1,3 +1,4 @@
+import { _isArray } from './_internals/_isArray'
 import { _isInteger } from './_internals/_isInteger'
 import { assoc } from './assoc'
 import { curry } from './curry'
@@ -29,7 +30,7 @@ function assocPathFn(
     )
   }
 
-  if (_isInteger(parseInt(index, 10)) && Array.isArray(input)){
+  if (_isInteger(parseInt(index, 10)) && _isArray(input)){
     const arr = input.slice()
     arr[ index ] = newValue
 

--- a/source/change.js
+++ b/source/change.js
@@ -1,10 +1,11 @@
 //Its lodash's set method taken from
 //https://github.com/lodash/lodash/blob/4.5.0-npm-packages
+import { _isArray } from './_internals/_isArray'
 import { set } from './_internals/set'
 import { partition } from './partition'
 
 const isObject = x => {
-  const ok = x !== null && !Array.isArray(x) && typeof x === 'object'
+  const ok = x !== null && !_isArray(x) && typeof x === 'object'
   if (!ok){
     return false
   }

--- a/source/clone.js
+++ b/source/clone.js
@@ -1,5 +1,7 @@
+import { _isArray } from './_internals/_isArray'
+
 export function clone(input){
-  const out = Array.isArray(input) ? Array(input.length) : {}
+  const out = _isArray(input) ? Array(input.length) : {}
   if (input && input.getTime) return new Date(input.getTime())
 
   for (const key in input){

--- a/source/count.js
+++ b/source/count.js
@@ -1,10 +1,11 @@
+import { _isArray } from './_internals/_isArray'
 import { equals } from './equals'
 
 export function count(searchFor, list){
   if (arguments.length === 1){
     return listHolder => count(searchFor, listHolder)
   }
-  if (!Array.isArray(list)) return 0
+  if (!_isArray(list)) return 0
 
   return list.filter(x => equals(x, searchFor)).length
 }

--- a/source/filter.js
+++ b/source/filter.js
@@ -1,3 +1,5 @@
+import { _isArray } from './_internals/_isArray'
+
 function filterObject(fn, obj){
   const willReturn = {}
 
@@ -17,7 +19,7 @@ export function filter(predicate, list){
 
   if (!list) return []
 
-  if (!Array.isArray(list)){
+  if (!_isArray(list)){
     return filterObject(predicate, list)
   }
 

--- a/source/filterAsync.js
+++ b/source/filterAsync.js
@@ -1,3 +1,4 @@
+import { _isArray } from './_internals/_isArray'
 import { filter } from './filter'
 import { mapAsync } from './mapAsync'
 
@@ -9,7 +10,7 @@ export function filterAsync(predicate, listOrObject){
   return new Promise((resolve, reject) => {
     mapAsync(predicate, listOrObject)
       .then(predicateResult => {
-        if (Array.isArray(predicateResult)){
+        if (_isArray(predicateResult)){
           const filtered = listOrObject.filter((_, i) => predicateResult[ i ])
 
           return resolve(filtered)

--- a/source/flatten.js
+++ b/source/flatten.js
@@ -1,8 +1,10 @@
+import { _isArray } from './_internals/_isArray'
+
 export function flatten(list, input){
   const willReturn = input === undefined ? [] : input
 
   for (let i = 0; i < list.length; i++){
-    if (Array.isArray(list[ i ])){
+    if (_isArray(list[ i ])){
       flatten(list[ i ], willReturn)
     } else {
       willReturn.push(list[ i ])

--- a/source/groupWith.js
+++ b/source/groupWith.js
@@ -1,5 +1,7 @@
+import { _isArray } from './_internals/_isArray'
+
 export function groupWith(compareFn, list){
-  if (!Array.isArray(list))
+  if (!_isArray(list))
     throw new TypeError('list.reduce is not a function')
 
   const clone = list.slice()

--- a/source/includes.js
+++ b/source/includes.js
@@ -1,3 +1,4 @@
+import { _isArray } from './_internals/_isArray'
 import { equals } from './equals'
 
 export function includes(valueToFind, input){
@@ -6,7 +7,7 @@ export function includes(valueToFind, input){
   if (typeof input === 'string'){
     return input.includes(valueToFind)
   }
-  if (!Array.isArray(input)) return false
+  if (!_isArray(input)) return false
 
   let index = -1
 

--- a/source/isValid.js
+++ b/source/isValid.js
@@ -1,3 +1,4 @@
+import { _isArray } from './_internals/_isArray'
 import { all } from './all'
 import { any } from './any'
 import { includes } from './includes'
@@ -36,7 +37,7 @@ const typesWithoutPrototype = [ 'any', 'promise', 'async', 'function' ]
 
 export function fromPrototypeToString(rule){
   if (
-    Array.isArray(rule) ||
+    _isArray(rule) ||
     rule === undefined ||
     rule === null ||
     rule.prototype === undefined ||

--- a/source/map.js
+++ b/source/map.js
@@ -1,3 +1,5 @@
+import { _isArray } from './_internals/_isArray'
+
 function mapObject(fn, obj){
   const willReturn = {}
 
@@ -16,7 +18,7 @@ export function map(fn, list){
   if (list === undefined){
     return []
   }
-  if (!Array.isArray(list)){
+  if (!_isArray(list)){
     return mapObject(fn, list)
   }
 

--- a/source/mapAsync.js
+++ b/source/mapAsync.js
@@ -1,5 +1,7 @@
+import { _isArray } from './_internals/_isArray'
+
 async function mapAsyncFn(fn, arr){
-  if (Array.isArray(arr)){
+  if (_isArray(arr)){
     const willReturn = []
     let i = 0
     for (const a of arr){

--- a/source/partition.js
+++ b/source/partition.js
@@ -1,3 +1,5 @@
+import { _isArray } from './_internals/_isArray'
+
 function whenObject(predicate, input){
   const yes = {}
   const no = {}
@@ -16,7 +18,7 @@ export function partition(predicate, input){
   if (arguments.length === 1){
     return listHolder => partition(predicate, listHolder)
   }
-  if (!Array.isArray(input)) return whenObject(predicate, input)
+  if (!_isArray(input)) return whenObject(predicate, input)
 
   const yes = []
   const no = []

--- a/source/transpose.js
+++ b/source/transpose.js
@@ -1,7 +1,9 @@
+import { _isArray } from './_internals/_isArray'
+
 export function transpose(array){
   return array.reduce((acc, el) => {
     el.forEach((nestedEl, i) =>
-      Array.isArray(acc[ i ]) ? acc[ i ].push(nestedEl) : acc.push([ nestedEl ]))
+      _isArray(acc[ i ]) ? acc[ i ].push(nestedEl) : acc.push([ nestedEl ]))
 
     return acc
   }, [])

--- a/source/type.js
+++ b/source/type.js
@@ -1,3 +1,5 @@
+import { _isArray } from './_internals/_isArray'
+
 export function type(input){
   const typeOf = typeof input
 
@@ -11,7 +13,7 @@ export function type(input){
     return Number.isNaN(input) ? 'NaN' : 'Number'
   } else if (typeOf === 'string'){
     return 'String'
-  } else if (Array.isArray(input)){
+  } else if (_isArray(input)){
     return 'Array'
   } else if (input instanceof RegExp){
     return 'RegExp'


### PR DESCRIPTION
Thoughts about stages you can read here #475 
Not all perf benchs showed. Processing power in some other function will speed up (transpose for ex.).

## Initalization stage
### filter (empty array):
**Before**
```js
  Rambda:
    5 045 006 ops/s, ±0.96%     | 95.58% slower
  Ramda:
    1 697 448 ops/s, ±1.48%     | slowest, 98.51% slower
  Lodash:
    114 056 063 ops/s, ±2.48%   | fastest
```
**After**
```js
  Rambda:
    287 421 997 ops/s, ±1.15%   | fastest
  Ramda:
    1 727 667 ops/s, ±1.27%     | slowest, 99.4% slower
  Lodash:
    120 056 085 ops/s, ±2.81%   | 58.23% slower
```

### clone (empty object):
**Before**
```js
  Rambda:
    5 006 674 ops/s, ±0.72%   | fastest
  Ramda:
    1 310 727 ops/s, ±2.16%   | slowest, 73.82% slower
  Lodash.cloneDeep:
    1 371 105 ops/s, ±1.97%   | 72.61% slower
```
**After**
```js
  Rambda:
    144 949 647 ops/s, ±1.19%   | fastest
  Ramda:
    1 264 141 ops/s, ±1.66%     | 99.13% slower
  Lodash.cloneDeep:
    1 090 004 ops/s, ±1.80%     | slowest, 99.25% slower
```
### map (empty array):
**Before**
```js
  Rambda:
    2 630 058 ops/s, ±0.81%   | 45.76% slower
  Ramda:
    1 244 835 ops/s, ±1.24%   | slowest, 74.33% slower
  Lodash:
    4 848 991 ops/s, ±1.22%   | fastest
```
**After**
```js
  Rambda:
    4 869 840 ops/s, ±1.14%   | fastest
  Ramda:
    1 207 391 ops/s, ±1.27%   | slowest, 75.21% slower
  Lodash:
    4 569 654 ops/s, ±1.23%   | 6.16% slower
```
### includes (empty array):
**Before**
```js
  Rambda:
    1 627 034 ops/s, ±1.27%   | slowest, 56.43% slower
  Ramda:
    3 734 149 ops/s, ±2.38%   | fastest
```
**After**
```js
  Rambda:
    34 637 306 ops/s, ±3.03%   | fastest
  Ramda:
    3 587 805 ops/s, ±2.41%    | slowest, 89.64% slowerfilter (empty array):
```
## Processing stage
### flatten (100x10x10):
**Before**
```js
  Rambda:
    433 ops/s, ±1.21%       | slowest, 99.59% slower
  Ramda:
    522 ops/s, ±2.35%       | 99.5% slower
  Lodash:
    104 409 ops/s, ±2.09%   | fastest
```
**After**
```js
  Rambda:
    11 127 ops/s, ±2.44%    | 90.21% slower
  Ramda:
    510 ops/s, ±2.64%       | slowest, 99.55% slower
  Lodash:
    113 605 ops/s, ±1.70%   | fastest
```