### PR TITLE
fix  groupWith works currently with single item lists as expected (in…

### DIFF
--- a/source/groupWith.js
+++ b/source/groupWith.js
@@ -5,6 +5,9 @@ export function groupWith(compareFn, list){
     throw new TypeError('list.reduce is not a function')
 
   const clone = list.slice()
+
+  if (list.length === 1) return [ clone ];
+
   const toReturn = []
   let holder = []
 

--- a/source/groupWith.spec.js
+++ b/source/groupWith.spec.js
@@ -89,3 +89,10 @@ test('from ramda 3', () => {
     [ 3, 4 ],
   ])
 })
+
+test('list with single item', () => {
+  const result = groupWith(equals, [ 0, ])
+
+  const expected = [[ 0 ]]
+  expect(result).toEqual(expected)
+})


### PR DESCRIPTION
Before:
groupWith  produces empty list if single item list is passed 
e.g groupWith(equals, [ 0, ]) - > []

After fix:
groupWith produces list with list of appropriate single item with if single item list is passed (as it works in ramda)
e.g groupWith(equals, [ 0, ]) - > []