### PR TITLE
Feat@method apply unapply bind

### DIFF
--- a/files/index.d.ts
+++ b/files/index.d.ts
@@ -4898,7 +4898,7 @@ const result = R.apply(Math.max, [42, -Infinity, 1337])
 // => 1337
 ```
 
-Categories:
+Categories: Function
 
 Notes:
 
@@ -4910,18 +4910,19 @@ export function apply<T = any>(fn: (...args: any[]) => T): (args: any[]) => T;
 /*
 Method: bind
 
-Explanation:
+Explanation: Creates a function that is bound to a context.
 
 Example:
 
 ```
-const result = R.bind()
-// => 
+const log = R.bind(console.log, console)
+const result = R.pipe(R.assoc('a', 2), R.tap(log), R.assoc('a', 3))({a: 1}); // => {a: 3}
+// => logs {a: 2}
 ```
 
-Categories:
+Categories: Function
 
-Notes:
+Notes: R.bind does not provide the additional argument-binding capabilities of [Function.prototype.bind](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind).
 
 */
 // @SINGLE_MARKER

--- a/files/index.d.ts
+++ b/files/index.d.ts
@@ -4866,6 +4866,68 @@ export function eqProps<T, U>(prop: string, obj1: T, obj2: U): boolean;
 export function eqProps<P extends string>(prop: P): <T, U>(obj1: Record<P, T>, obj2: Record<P, U>) => boolean;
 export function eqProps<T>(prop: string, obj1: T): <U>(obj2: U) => boolean;
 
+/*
+Method: unapply
+
+Explanation: It calls a function `fn` with the list of values of the returned function. `R.unapply` is the inverse of `R.apply`
+
+Example:
+
+```
+R.unapply(JSON.stringify)(1, 2, 3)
+//=> '[1,2,3]'
+```
+
+Categories: Function
+
+Notes:
+
+*/
+// @SINGLE_MARKER
+export function unapply<T = any>(fn: (args: any[]) => T): (...args: any[]) => T;
+
+/*
+Method: apply
+
+Explanation: It applies function fn to the argument list args. This is useful for creating a fixed-arity function from a variadic function. fn should be a bound function if context is significant.
+
+Example:
+
+```
+const result = R.apply(Math.max, [42, -Infinity, 1337])
+// => 1337
+```
+
+Categories:
+
+Notes:
+
+*/
+// @SINGLE_MARKER
+export function apply<T = any>(fn: (...args: any[]) => T, args: any[]): T;
+export function apply<T = any>(fn: (...args: any[]) => T): (args: any[]) => T;
+
+/*
+Method: bind
+
+Explanation:
+
+Example:
+
+```
+const result = R.bind()
+// => 
+```
+
+Categories:
+
+Notes:
+
+*/
+// @SINGLE_MARKER
+export function bind<F extends (...args: any[]) => any, T>(fn: F, thisObj: T): (...args: Parameters<F>) => ReturnType<F>;
+export function bind<F extends (...args: any[]) => any, T>(fn: F): (thisObj: T) => (...args: Parameters<F>) => ReturnType<F>;
+
 // RAMBDAX_MARKER_START
 
 /*

--- a/index.d.ts
+++ b/index.d.ts
@@ -164,6 +164,14 @@ export function and<T, U>(x: T, y: U): T | U;
 export function and<T>(x: T): <U>(y: U) => T | U;
 
 /**
+ *
+ * Creates a function that is bound to a context. Note: R.bind does not provide the additional argument-binding capabilities of Function.prototype.bind.
+ */
+export function bind<T, U>(fn: (this: T, x: any) => U, y: any): U;
+export function bind<T, U>(fn: (x: any) => U, y: any): U;
+
+
+/**
  * Logical OR
  */
 export function or<T, U>(a: T, b: U): T | U;
@@ -185,6 +193,15 @@ export function anyPass<T>(predicates: SafePred<T>[]): SafePred<T>;
  */
 export function append<T>(x: T, list: T[]): T[];
 export function append<T>(x: T): <T>(list: T[]) => T[];
+
+/**
+ * It applies function fn to the argument list args. This is useful for creating a fixed-arity function from a variadic function. fn should be a bound function if context is significant.
+ */
+export function apply<T, U>(fn: (...args: T[]) => U, ...args: T[]): U;
+export function apply<T, U>(fn: (...args: T[]) => U): (...args: T[]) => U;
+export function apply<T>(fn: (...args: any[]) => T, ...args: any[]): T;
+export function apply<T>(fn: (...args: any[]) => T): (...args: any[]) => T;
+
 
 export function applySpec<Spec extends Record<string, (...args: any[]) => any>>(
   spec: Spec

--- a/source/apply-spec.ts
+++ b/source/apply-spec.ts
@@ -1,0 +1,15 @@
+import { apply, identity } from 'rambda'
+
+describe('R.apply', () => {
+  it('happy', () => {
+    const result = apply<number>(identity, [1, 2, 3])
+
+    result // $ExpectType number
+  })
+  it('curried', () => {
+    const fn = apply<number>(identity)
+    const result = fn([1, 2, 3])
+
+    result // $ExpectType number
+  })
+})

--- a/source/apply.js
+++ b/source/apply.js
@@ -1,0 +1,7 @@
+export function apply(fn, args) {
+  if (arguments.length === 1){
+    return (_args) => apply(fn, _args);
+  }
+
+  return fn.apply(this, args);
+}

--- a/source/apply.spec.js
+++ b/source/apply.spec.js
@@ -1,0 +1,21 @@
+import {apply} from './apply'
+import {bind} from './bind'
+import {identity} from './identity';
+
+test('happy', () => {
+  expect(apply(identity, [1, 2, 3])).toEqual(1)
+})
+
+test('applies function to argument list', function () {
+  expect(apply(Math.max, [1, 2, 3, -99, 42, 6, 7])).toEqual(42);
+});
+
+test('provides no way to specify context', function () {
+  const obj = {
+    method: function () {
+      return this === obj;
+    }
+  };
+  expect(apply(obj.method, [])).toEqual(false);
+  expect(apply(bind(obj.method, obj), [])).toEqual(true);
+});

--- a/source/bind-spec.ts
+++ b/source/bind-spec.ts
@@ -1,0 +1,15 @@
+import { bind } from 'rambda'
+
+class Foo {}
+function isFoo<T = any>(this: T): boolean {
+  return this instanceof Foo;
+}
+
+describe('R.bind', () => {
+  it('happy', () => {
+    const foo = new Foo();
+    const result = bind(isFoo, foo)()
+
+    result // $ExpectType boolean
+  })
+})

--- a/source/bind.js
+++ b/source/bind.js
@@ -1,0 +1,10 @@
+import {curryN} from './curryN';
+
+export function bind(fn, thisObj) {
+  if (arguments.length === 1){
+    return (_thisObj) => bind(fn, _thisObj);
+  }
+  return curryN(fn.length,
+    (...args) => fn.apply(thisObj, args)
+  )
+}

--- a/source/bind.spec.js
+++ b/source/bind.spec.js
@@ -1,0 +1,79 @@
+import { bind } from './bind'
+
+function Foo(x) {
+  this.x = x;
+}
+function add(x) {
+  return this.x + x;
+}
+function Bar(x, y) {
+  this.x = x;
+  this.y = y;
+}
+Bar.prototype = new Foo();
+Bar.prototype.getX = function() {
+  return 'prototype getX';
+};
+
+test('returns a function', function() {
+  expect(typeof bind(add, Foo)).toEqual('function');
+});
+
+test('returns a function bound to the specified context object', function() {
+  const f = new Foo(12);
+  function isFoo() {
+    return this instanceof Foo;
+  }
+  const isFooBound = bind(isFoo, f);
+  expect(isFoo()).toEqual(false);
+  expect(isFooBound()).toEqual(true);
+});
+
+test('works with built-in types', function() {
+  const abc = bind(String.prototype.toLowerCase, 'ABCDEFG');
+  expect(typeof abc).toEqual('function');
+  expect(abc()).toEqual('abcdefg');
+});
+
+test('works with user-defined types', function() {
+  const f = new Foo(12);
+  function getX() {
+    return this.x;
+  }
+  const getXFooBound = bind(getX, f);
+  expect(getXFooBound()).toEqual(12);
+});
+
+test('works with plain objects', function() {
+  const pojso = {
+    x: 100
+  };
+  function incThis() {
+    return this.x + 1;
+  }
+  const incPojso = bind(incThis, pojso);
+  expect(typeof incPojso).toEqual('function');
+  expect(incPojso()).toEqual(101);
+});
+
+test('does not interfere with existing object methods', function() {
+  const b = new Bar('a', 'b');
+  function getX() {
+    return this.x;
+  }
+  const getXBarBound = bind(getX, b);
+  expect(b.getX()).toEqual('prototype getX');
+  expect(getXBarBound()).toEqual('a');
+});
+
+test('preserves arity', function() {
+  const f0 = function() { return 0; };
+  const f1 = function(a) { return a; };
+  const f2 = function(a, b) { return a + b; };
+  const f3 = function(a, b, c) { return a + b + c; };
+
+  expect(bind(f0, {}).length).toEqual(0);
+  expect(bind(f1, {}).length).toEqual(1);
+  expect(bind(f2, {}).length).toEqual(2);
+  expect(bind(f3, {}).length).toEqual(3);
+});

--- a/source/converge-spec.ts
+++ b/source/converge-spec.ts
@@ -1,4 +1,4 @@
-import {converge} from 'ramda'
+import {converge} from 'rambda'
 
 const mult = (a: number, b: number) => {
   return a * b

--- a/source/unapply-spec.ts
+++ b/source/unapply-spec.ts
@@ -1,0 +1,15 @@
+import {join, unapply, sum} from 'rambda'
+
+describe('R.unapply', () => {
+  it('happy', () => {
+    const fn = unapply(sum)
+    
+    fn(1, 2, 3) // $ExpectType number
+  })
+
+  it('joins a string', () => {
+    const fn = unapply(join(''))
+
+    fn('s', 't', 'r', 'i', 'n', 'g') // $ExpectType string
+  })
+})

--- a/source/unapply.js
+++ b/source/unapply.js
@@ -1,0 +1,5 @@
+export function unapply(fn) {
+  return function(...args) {
+    return fn.call(this, args || []);
+  }
+}

--- a/source/unapply.spec.js
+++ b/source/unapply.spec.js
@@ -1,0 +1,71 @@
+import { apply } from './apply'
+import { unapply } from './unapply'
+import { identity } from './identity';
+import { converge } from './converge';
+import { prop } from './prop';
+import { sum } from './sum';
+
+test('happy', () => {
+  const fn = unapply(identity)
+  expect(fn(1, 2, 3)).toEqual([1, 2, 3])
+})
+
+test('returns a function which is always passed one argument', function() {
+  const fn = unapply(function() { return arguments.length; });
+  expect(fn('x')).toEqual(1);
+  expect(fn('x', 'y')).toEqual(1);
+  expect(fn('x', 'y', 'z')).toEqual(1);
+});
+
+test('forwards arguments to decorated function as an array', function() {
+  const fn = unapply(function(xs) { return '[' + xs + ']'; });
+  expect(fn(2)).toEqual( '[2]');
+  expect(fn(2, 4)).toEqual( '[2,4]');
+  expect(fn(2, 4, 6)).toEqual( '[2,4,6]');
+});
+
+test('returns a function with length 0', function() {
+  const fn = unapply(identity);
+  expect(fn.length).toEqual(0);
+});
+
+test('is the inverse of R.apply', function() {
+  let a, b, c, d, e, f, g, n;
+  const rand = function() {
+    return Math.floor(200 * Math.random()) - 100;
+  };
+
+  f = Math.max;
+  g = unapply(apply(f));
+  n = 1;
+  while (n <= 100) {
+    a = rand(); b = rand(); c = rand(); d = rand(); e = rand();
+    expect(f(a, b, c, d, e)).toEqual(g(a, b, c, d, e));
+    n += 1;
+  }
+
+  f = function(xs) { return '[' + xs + ']'; };
+  g = apply(unapply(f));
+  n = 1;
+  while (n <= 100) {
+    a = rand(); b = rand(); c = rand(); d = rand(); e = rand();
+    expect(f([a, b, c, d, e])).toEqual(g([a, b, c, d, e]));
+    n += 1;
+  }
+});
+
+test('it works with converge', () => {
+  const fn = unapply(sum)
+  const convergeFn = converge(fn, [
+    prop('a'),
+    prop('b'),
+    prop('c'),
+  ])
+  const obj = {
+    a: 1337,
+    b: 42,
+    c: 1,
+  }
+  const expected = 1337 + 42 + 1;
+  expect(convergeFn(obj)).toEqual(expected)
+})


### PR DESCRIPTION
Hey Dejan,

New methods apply, unapply & bind. also a minor bugfix in the converge typescript test as it was referencing ramda not rambda.

Typescript defs are done, methods, tests. I had some trouble coming up with typescript tests for bind, I couldn't get the return type to be what the context is, but this kind of does the same thing proving the context.

No benchmarks as it's not listed in the CONTRIBUTING docs. There is also an error when running `yarn out`. I have installed the rambda-scripts repo in the correct place and can run `yarn new method`. 

```
*(feat@method-apply-unapply-bind)[~/projects/rambda] λ yarn out
yarn run v1.22.11
$ yarn populatedocs && yarn populatereadme && yarn immutable && yarn build
$ cd ../rambda-scripts && yarn populate:docs
$ RAMBDA_SCRIPTS_MODE=populate:docs jest src/apply-rambda-scripts.spec.ts
 FAIL  src/apply-rambda-scripts.spec.ts
  ✕ happy (238 ms)

  ● happy

    ENOENT: no such file or directory, scandir '/Users/andrewfo/projects/rambda-scripts/scripts/run-benchmarks/benchmarks/benchmark_results'

      36 |     lodash: 0,
      37 |   }
    > 38 |   const allResults = readdirSync(resultsDir)
         |                      ^
      39 |
      40 |   const tableRows = allResults.map(file => {
      41 |     const {results, name} = readResults(file)

      at Object.<anonymous> (src/read-benchmarks/benchmark-summary.ts:38:22)
      at step (src/read-benchmarks/benchmark-summary.ts:33:23)
      at Object.next (src/read-benchmarks/benchmark-summary.ts:14:53)
      at src/read-benchmarks/benchmark-summary.ts:8:71
      at Object.<anonymous>.__awaiter (src/read-benchmarks/benchmark-summary.ts:4:12)
      at Object.benchmarkSummary (src/read-benchmarks/benchmark-summary.ts:57:12)
      at Object.<anonymous> (src/populate-docs-data/extracts/benchmark-info.ts:49:9)
      at step (src/populate-docs-data/extracts/benchmark-info.ts:33:23)

  console.log
    benchmarkInfo

      at Object.<anonymous> (src/populate-docs-data/extracts/benchmark-info.ts:48:11)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        4.966 s
Ran all test suites matching /src\/apply-rambda-scripts.spec.ts/i.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
*(feat@method-apply-unapply-bind)[~/projects/rambda] λ 
```

Cheers,

Andrew