### PR TITLE
feat: Improved docs "title" tag

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Document</title>
+  <title>Rambda Documentation</title>
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="description" content="Description">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">


### PR DESCRIPTION
Currently the Rambda documentation site has a title of "Document". This PR should change it to "Rambda Documentation".
<img width="235" alt="image" src="https://user-images.githubusercontent.com/14135212/147790412-60824db7-c812-463d-ac71-adf0e7190dee.png">
