### PR TITLE
chore: export immutable.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,12 @@
       "require": "./dist/rambda.js",
       "default": "./dist/rambda.js",
       "types": "./index.d.ts"
+    },
+    "./immutable": {
+      "import": "./immutable.js",
+      "require": "./immutable.js",
+      "default": "./immutable.js",
+      "types": "./immutable.d.ts"
     }
   },
   "keywords": [


### PR DESCRIPTION
Now I receive the following error when using with ts-node:

`Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './immutable' is not defined by "exports" in <PATH_TO_PROJECT>/node_modules/rambda/package.json`