### PR TITLE
feat: Improve `startsWith`, `includes` and `endsWith` typings for TS 4.5

### DIFF
--- a/files/index.d.ts
+++ b/files/index.d.ts
@@ -1013,8 +1013,8 @@ Notes:
 
 */
 // @SINGLE_MARKER
-export function endsWith(target: string, iterable: string): boolean;
-export function endsWith(target: string): (iterable: string) => boolean;
+export function endsWith<T extends string>(target: T, str: string): str is `${string}${T}`;
+export function endsWith<T extends string>(target: T): (str: string) => str is `${string}${T}`;
 export function endsWith<T>(target: T[], list: T[]): boolean;
 export function endsWith<T>(target: T[]): (list: T[]) => boolean;
 

--- a/files/index.d.ts
+++ b/files/index.d.ts
@@ -1557,8 +1557,8 @@ Notes:
 
 */
 // @SINGLE_MARKER
-export function includes(valueToFind: string, input: string[] | string): boolean;
-export function includes(valueToFind: string): (input: string[] | string) => boolean;
+export function includes<T extends string>(valueToFind: T, input: string): input is `${string}${T}${string}`;
+export function includes<T extends string>(valueToFind: T): (input: string) => input is `${string}${T}${string}`;
 export function includes<T>(valueToFind: T, input: T[]): boolean;
 export function includes<T>(valueToFind: T): (input: T[]) => boolean;
 

--- a/files/index.d.ts
+++ b/files/index.d.ts
@@ -3616,8 +3616,8 @@ Notes: It doesn't work with arrays unlike its corresponding **Ramda** method.
 
 */
 // @SINGLE_MARKER
-export function startsWith(target: string, str: string): boolean;
-export function startsWith(target: string): (str: string) => boolean;
+export function startsWith<T extends string>(target: T, str: string): str is `${T}${string}`;
+export function startsWith<T extends string>(target: T): (str: string) => str is `${T}${string}`;
 export function startsWith<T>(target: T[], list: T[]): boolean;
 export function startsWith<T>(target: T[]): (list: T[]) => boolean;
 

--- a/source/endsWith-spec.ts
+++ b/source/endsWith-spec.ts
@@ -17,15 +17,23 @@ describe('R.endsWith - array as iterable', () => {
 
 describe('R.endsWith - string as iterable', () => {
   const target = 'bar'
-  const iterable = 'foo bar'
+  const iterable = 'foo bar' as 'foo bar' | 'happy' | 'happy-2'
   it('happy', () => {
     const result = endsWith(target, iterable)
 
-    result // $ExpectType boolean
+    if (result) {
+      iterable // $ExpectType "foo bar"
+    }
+    
+    result; // $ExpectType boolean
   })
   it('curried', () => {
     const result = endsWith(target)(iterable)
 
-    result // $ExpectType boolean
+    if (result) {
+      iterable // $ExpectType "foo bar"
+    }
+
+    result; // $ExpectType boolean
   })
 })

--- a/source/includes-spec.ts
+++ b/source/includes-spec.ts
@@ -6,12 +6,23 @@ describe('R.includes', () => {
   it('happy', () => {
     const result = includes({a: {b: '1'}}, list)
     result // $ExpectType boolean
+    const result2 = includes('oo', ['f', 'oo'])
+    result2 // $ExpectType boolean
   })
   it('with string', () => {
-    const result = includes('oo', 'foo')
-    const curriedResult = includes('oo')('foo')
+    const str = 'foo' as 'foo' | 'bar'
+    const result = includes('oo', str)
+    const curriedResult = includes('oo')(str)
 
     result // $ExpectType boolean
     curriedResult // $ExpectType boolean
+
+    if (result) {
+      str // $ExpectType "foo"
+    }
+
+    if (curriedResult) {
+      str // $ExpectType "foo"
+    }
   })
 })

--- a/source/startsWith-spec.ts
+++ b/source/startsWith-spec.ts
@@ -17,15 +17,25 @@ describe('R.startsWith - array as iterable', () => {
 
 describe('R.startsWith - string as iterable', () => {
   const target = 'foo'
-  const iterable = 'foo bar'
+  const iterable = 'foo bar' as 'foo bar' | 'happy' | 'happy-2'
   it('happy', () => {
     const result = startsWith(target, iterable)
 
     result // $ExpectType boolean
+    
+    if (result) {
+      //@ts-expect-error
+      iterable === 'happy'
+    }
   })
   it('curried', () => {
     const result = startsWith(target)(iterable)
 
-    result // $ExpectType boolean
+    result; // $ExpectType boolean
+
+    if (result) {
+      //@ts-expect-error
+      iterable === 'happy'
+    }
   })
 })

--- a/source/startsWith-spec.ts
+++ b/source/startsWith-spec.ts
@@ -22,10 +22,9 @@ describe('R.startsWith - string as iterable', () => {
     const result = startsWith(target, iterable)
 
     result // $ExpectType boolean
-    
+
     if (result) {
-      //@ts-expect-error
-      iterable === 'happy'
+      iterable // $ExpectType "foo bar"
     }
   })
   it('curried', () => {
@@ -34,8 +33,7 @@ describe('R.startsWith - string as iterable', () => {
     result; // $ExpectType boolean
 
     if (result) {
-      //@ts-expect-error
-      iterable === 'happy'
+      iterable // $ExpectType "foo bar"
     }
   })
 })


### PR DESCRIPTION
There might be a better title for this PR.

Starting from TypeScript 4.5 strings can be narrowed: 
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#template-string-types-as-discriminants

Also see https://github.com/microsoft/TypeScript/pull/46137#issuecomment-932730666

Should I do the same in `@types/ramda` as well?

Also I noticed absence of formatter. Don't you mind enabling something like Prettier?