### PR TITLE
fix@always compatibility with applySpec

### DIFF
--- a/source/always.js
+++ b/source/always.js
@@ -1,3 +1,3 @@
 export function always(x) {
-  return () => x
+  return (_) => x
 }

--- a/source/always.spec.js
+++ b/source/always.spec.js
@@ -1,4 +1,5 @@
 import {always} from './always'
+import {applySpec} from './applySpec'
 import {F} from './F'
 
 test('happy', () => {
@@ -13,4 +14,9 @@ test('f', () => {
 
   expect(fn()).toBeFalse()
   expect(fn()).toBeFalse()
+})
+
+test('compatibility with applySpec', () => {
+  const spec = applySpec({ x: always('foo') });
+  expect(spec({})).toEqual({ x: 'foo' });
 })


### PR DESCRIPTION
Hey Dejan!

`applySpec` did not work with `always` because it didn't have any argument length.

This fix will not affect any other code. 

`applySpec` may need to be updated where a function with no arguments is provided.