### PR TITLE
feat: add nop method

### DIFF
--- a/files/index.d.ts
+++ b/files/index.d.ts
@@ -2582,6 +2582,26 @@ export function none<T>(predicate: (x: T) => boolean, list: T[]): boolean;
 export function none<T>(predicate: (x: T) => boolean): (list: T[]) => boolean;
 
 /*
+Method: nop
+
+Explanation: It returns `undefined`.
+
+Example:
+
+```
+const result = R.nop()
+// => undefined
+```
+
+Categories:
+
+Notes:
+
+*/
+// @SINGLE_MARKER
+export function nop(): void;
+
+/*
 Method: not
 
 Explanation: It returns a boolean negated version of `input`.

--- a/source/nop-spec.ts
+++ b/source/nop-spec.ts
@@ -1,0 +1,8 @@
+import {nop} from 'rambda'
+
+describe('R.nop', () => {
+  it('call', () => {
+    const result = nop()
+    result // $ExpectType void
+  })
+})

--- a/source/nop.js
+++ b/source/nop.js
@@ -1,0 +1,1 @@
+export function nop(){}

--- a/source/nop.spec.js
+++ b/source/nop.spec.js
@@ -1,0 +1,5 @@
+import { nop } from './nop.js'
+
+test('call', () => {
+  expect(nop).not.toThrow()
+})


### PR DESCRIPTION
This PR adds the `nop()` method, which does nothing and can be used as a placeholder or default value for function types. It fulfills a similar role than `R.identity` does.

Admittedly, this one doesn't match any `ramda` methods, but `rambda`'s goal of being an utility belt makes it the best place where to add this function. I often end up repeating `const NOOP = () => {}` in many points in my projects due to the absence of this function.