### PR TITLE
fix: cleaner dropWhile/dropLastWhile/takeWhile/takeLastwhile

### DIFF
--- a/source/dropLastWhile.js
+++ b/source/dropLastWhile.js
@@ -14,18 +14,19 @@ export function dropLastWhile(predicate, iterable){
     throw new Error(`'iterable' is from wrong type ${ typeof iterable }`)
   }
 
-  let found = false
   const toReturn = []
   let counter = iterable.length
 
-  while (counter > 0){
-    counter--
-    if (!found && predicate(iterable[ counter ]) === false){
-      found = true
-      toReturn.push(iterable[ counter ])
-    } else if (found){
-      toReturn.push(iterable[ counter ])
+  while (counter){
+    const item = iterable[ --counter ]
+    if (!predicate(item)){
+      toReturn.push(item)
+      break
     }
+  }
+
+  while (counter){
+    toReturn.push(iterable[ --counter ])
   }
 
   return isArray ? toReturn.reverse() : toReturn.reverse().join('')

--- a/source/dropWhile.js
+++ b/source/dropWhile.js
@@ -8,19 +8,21 @@ export function dropWhile(predicate, iterable){
   if (!isArray && typeof iterable !== 'string'){
     throw new Error('`iterable` is neither list nor a string')
   }
-  let flag = false
-  const holder = []
-  let counter = -1
 
-  while (counter++ < iterable.length - 1){
-    if (flag){
-      holder.push(iterable[ counter ])
-    } else if (!predicate(iterable[ counter ])){
-      if (!flag) flag = true
+  const toReturn = []
+  let counter = 0
 
-      holder.push(iterable[ counter ])
+  while (counter < iterable.length){
+    const item = iterable[ counter++ ]
+    if (!predicate(item)){
+      toReturn.push(item)
+      break
     }
   }
 
-  return isArray ? holder : holder.join('')
+  while (counter < iterable.length){
+    toReturn.push(iterable[ counter++ ])
+  }
+
+  return isArray ? toReturn : toReturn.join('')
 }

--- a/source/takeLastWhile.js
+++ b/source/takeLastWhile.js
@@ -5,17 +5,16 @@ export function takeLastWhile(predicate, input){
     return _input => takeLastWhile(predicate, _input)
   }
   if (input.length === 0) return input
-  let found = false
+
   const toReturn = []
   let counter = input.length
 
-  while (!found && counter){
-    counter--
-    if (predicate(input[ counter ]) === false){
-      found = true
-    } else if (!found){
-      toReturn.push(input[ counter ])
+  while (counter){
+    const item = input[ --counter ]
+    if (!predicate(item)){
+      break
     }
+    toReturn.push(item)
   }
 
   return isArray(input) ? toReturn.reverse() : toReturn.reverse().join('')

--- a/source/takeWhile.js
+++ b/source/takeWhile.js
@@ -8,18 +8,17 @@ export function takeWhile(predicate, iterable){
   if (!isArray && typeof iterable !== 'string'){
     throw new Error('`iterable` is neither list nor a string')
   }
-  let flag = true
-  const holder = []
-  let counter = -1
 
-  while (counter++ < iterable.length - 1){
-    if (!predicate(iterable[ counter ])){
-      if (flag) flag = false
-    } else if (flag){
-      holder.push(iterable[ counter ])
+  const toReturn = []
+  let counter = 0
+
+  while (counter < iterable.length){
+    const item = iterable[ counter++ ]
+    if (!predicate(item)){
+      break
     }
+    toReturn.push(item)
   }
-  holder
 
-  return isArray ? holder : holder.join('')
+  return isArray ? toReturn : toReturn.join('')
 }


### PR DESCRIPTION
There was some sub-optimal code in these functions. I tried to clean it up while keeping your coding style :smile: 

- don't access iterable more than once per counter
- kill unnecessary boolean flag
- predicate can return falsy, not just false
- don't call predicate on items pointlessly (takeWhile)