### PR TITLE
Fix `R.append`'s curried type

### DIFF
--- a/files/index.d.ts
+++ b/files/index.d.ts
@@ -415,7 +415,7 @@ Notes:
 */
 // @SINGLE_MARKER
 export function append<T>(x: T, list: T[]): T[];
-export function append<T>(x: T): <T>(list: T[]) => T[];
+export function append<T>(x: T): (list: T[]) => T[];
 
 /*
 Method: applySpec

--- a/source/append-spec.ts
+++ b/source/append-spec.ts
@@ -5,12 +5,14 @@ const list = [1, 2, 3]
 describe('R.append', () => {
   it('happy', () => {
     const result = append(4, list)
-
     result // $ExpectType number[]
   })
-  it('curried', () => {
-    const result = append(4)(list)
 
+  it('curried', () => {
+    const curried = append(4)
+    curried // $ExpectType (list: number[]) => number[]
+
+    const result = curried(list)
     result // $ExpectType number[]
   })
 })


### PR DESCRIPTION
The type parameter was declared a second time by mistake, causing the two `T`s to be different type parameters.

**Before:** `R.append(4)` had type `(list: T[]) => T[]`

**After:** `R.append(4)` has type `(list: number[]) => number[]`