### PR TITLE
`R.anyPass()` can function as a type guard

### DIFF
--- a/files/index.d.ts
+++ b/files/index.d.ts
@@ -391,6 +391,7 @@ Notes:
 
 */
 // @SINGLE_MARKER
+export function anyPass<T, U extends T[]>(predicates: { [K in keyof U]: (x: T) => x is U[K]; }): (input: T) => input is U[number];
 export function anyPass<T>(predicates: ((x: T) => boolean)[]): (input: T) => boolean;
 export function anyPass<T>(predicates: ((...inputs: T[]) => boolean)[]): (...inputs: T[]) => boolean;
 

--- a/source/anyPass-spec.ts
+++ b/source/anyPass-spec.ts
@@ -32,4 +32,19 @@ describe('anyPass', () => {
     const filtered2 = xs.filter(pred)
     filtered2 // $ExpectType number[]
   })
+  it('functions as a type guard', () => {
+    const isString = (x: unknown): x is string => typeof x === 'string';
+    const isNumber = (x: unknown): x is number => typeof x === 'number';
+    const isBoolean = (x: unknown): x is boolean => typeof x === 'boolean';
+    
+    const isStringNumberOrBoolean = anyPass([isString, isNumber, isBoolean]);
+
+    isStringNumberOrBoolean // $ExpectType (input: unknown) => input is string | number | boolean
+
+    const aValue: unknown = 1;
+
+    if (isStringNumberOrBoolean(aValue)) {
+      aValue // $ExpectType string | number | boolean
+    }
+  })
 })


### PR DESCRIPTION
In the specific case where `R.anyPass()` is combining unary type guards, it can now serve as a unary type guard itself. This allows you to do things like:

```ts
const isJsonLiteral = anyPass([isString, isNumber, isBoolean, isNull]);
```

I would have liked to do `allPass` as well for completeness, but the TypeScript is much more complex, and I'm not sure it comes up as much.