### PR TITLE
`reduce()`: Reducer always receives an index

### DIFF
--- a/files/index.d.ts
+++ b/files/index.d.ts
@@ -3458,8 +3458,8 @@ Notes: It passes index of the list as third argument to `reducer` function.
 // @SINGLE_MARKER
 export function reduce<T, TResult>(reducer: (prev: TResult, current: T, i: number) => TResult, initialValue: TResult, list: T[]): TResult;
 export function reduce<T, TResult>(reducer: (prev: TResult, current: T) => TResult, initialValue: TResult, list: T[]): TResult;
-export function reduce<T, TResult>(reducer: (prev: TResult, current: T, i?: number) => TResult): (initialValue: TResult, list: T[]) => TResult;
-export function reduce<T, TResult>(reducer: (prev: TResult, current: T, i?: number) => TResult, initialValue: TResult): (list: T[]) => TResult;
+export function reduce<T, TResult>(reducer: (prev: TResult, current: T, i: number) => TResult): (initialValue: TResult, list: T[]) => TResult;
+export function reduce<T, TResult>(reducer: (prev: TResult, current: T, i: number) => TResult, initialValue: TResult): (list: T[]) => TResult;
 
 /*
 Method: reject

--- a/source/reduce-spec.ts
+++ b/source/reduce-spec.ts
@@ -45,6 +45,20 @@ describe('R.reduce', () => {
     result // $ExpectType number
   })
 
+  it('with index, curried', () => {
+    const result = reduce<number, number>(
+      (acc, elem, i) => {
+        acc // $ExpectType number
+        elem // $ExpectType number
+        i // $ExpectType number
+        return acc + elem
+      },
+      1,
+    )([1, 2, 3])
+
+    result // $ExpectType number
+  })
+
   it('using `reduceStopper` to stop the loop', () => {
     const result = reduce<number, number>(
       (acc, elem, i) => {


### PR DESCRIPTION
The index may be ignored by the reducer, but `reduce()` still provides it. If it's bound to a function parameter, the parameter's value will never be `undefined`; it will always be a `number`.

This mirrors `Array.prototype.map()`, and is already reflected in the first overload of `reduce()`, so I believe this was just a mistake.