### PR TITLE
Use `strict: true`

### DIFF
--- a/source/tsconfig.json
+++ b/source/tsconfig.json
@@ -4,12 +4,9 @@
     "lib": ["es2015", "dom"],
     "module": "esnext",
     "noEmit": true,
-    "noImplicitAny": true,
-    "noImplicitThis": true,
     "noUnusedLocals": true,
     "skipLibCheck": true,
-    "strictFunctionTypes": true,
-    "strictNullChecks": true,
+    "strict": true,
     "target": "es2015",
     "paths": { "rambda": ["../files/index.d.ts"], "ramda": ["../node_modules/types-ramda/es/index.d.ts"] }
   } 


### PR DESCRIPTION
Having `strict` off makes it harder for clients of this library to use `strict` themselves. But it appears to turn on without any type issues, so my guess is that there were tricky types in the past which have since been resolved.

I'd understand if you have reservations about turning it on, but I'd highly recommend it, given it turns on cleanly right now.