### PR TITLE
Improve composition operators

### DIFF
--- a/files/index.d.ts
+++ b/files/index.d.ts
@@ -5727,9 +5727,9 @@ export function composeAsync<TArg, R1, R2, R3, R4, R5, R6, R7, TResult>(
       f4: (a: Awaited<R3>) => R4,
       f3: (a: Awaited<R2>) => R3,
       f2: (a: Awaited<R1>) => R2,
-      f1: (a: TArg) => R1
+      f1: (a: Awaited<TArg>) => R1
   ]
-): (a: TArg) => TResult; // fallback overload if number of composed functions greater than 7
+): (a: TArg | Promise<TArg>) => TResult; // fallback overload if number of composed functions greater than 7
 export function composeAsync<TArg, R1, R2, R3, R4, R5, R6, R7, TResult>(
   f7: (a: Awaited<R6>) => R7,
   f6: (a: Awaited<R5>) => R6,
@@ -5737,8 +5737,8 @@ export function composeAsync<TArg, R1, R2, R3, R4, R5, R6, R7, TResult>(
   f4: (a: Awaited<R3>) => R4,
   f3: (a: Awaited<R2>) => R3,
   f2: (a: Awaited<R1>) => R2,
-  f1: (a: TArg) => R1
-): (a: TArg) => R7;
+  f1: (a: Awaited<TArg>) => R1
+): (a: TArg | Promise<TArg>) => R7;
 export function composeAsync<TArg, R1, R2, R3, R4, R5, R6, R7>(
   f7: (a: Awaited<R6>) => R7,
   f6: (a: Awaited<R5>) => R6,
@@ -5746,41 +5746,41 @@ export function composeAsync<TArg, R1, R2, R3, R4, R5, R6, R7>(
   f4: (a: Awaited<R3>) => R4,
   f3: (a: Awaited<R2>) => R3,
   f2: (a: Awaited<R1>) => R2,
-  f1: (a: TArg) => R1
-): (a: TArg) => R7;
+  f1: (a: Awaited<TArg>) => R1
+): (a: TArg | Promise<TArg>) => R7;
 export function composeAsync<TArg, R1, R2, R3, R4, R5, R6>(
   f6: (a: Awaited<R5>) => R6,
   f5: (a: Awaited<R4>) => R5,
   f4: (a: Awaited<R3>) => R4,
   f3: (a: Awaited<R2>) => R3,
   f2: (a: Awaited<R1>) => R2,
-  f1: (a: TArg) => R1
-): (a: TArg) => R6;
+  f1: (a: Awaited<TArg>) => R1
+): (a: TArg | Promise<TArg>) => R6;
 export function composeAsync<TArg, R1, R2, R3, R4, R5>(
   f5: (a: Awaited<R4>) => R5,
   f4: (a: Awaited<R3>) => R4,
   f3: (a: Awaited<R2>) => R3,
   f2: (a: Awaited<R1>) => R2,
-  f1: (a: TArg) => R1
-): (a: TArg) => R5;
+  f1: (a: Awaited<TArg>) => R1
+): (a: TArg | Promise<TArg>) => R5;
 export function composeAsync<TArg, R1, R2, R3, R4>(
   f4: (a: Awaited<R3>) => R4,
   f3: (a: Awaited<R2>) => R3,
   f2: (a: Awaited<R1>) => R2,
-  f1: (a: TArg) => R1
-): (a: TArg) => R4;
+  f1: (a: Awaited<TArg>) => R1
+): (a: TArg | Promise<TArg>) => R4;
 export function composeAsync<TArg, R1, R2, R3>(
   f3: (a: Awaited<R2>) => R3,
   f2: (a: Awaited<R1>) => R2,
-  f1: (a: TArg) => R1
-): (a: TArg) => R3;
+  f1: (a: Awaited<TArg>) => R1
+): (a: TArg | Promise<TArg>) => R3;
 export function composeAsync<TArg, R1, R2>(
   f2: (a: Awaited<R1>) => R2,
-  f1: (a: TArg) => R1
-): (a: TArg) => R2;
+  f1: (a: Awaited<TArg>) => R1
+): (a: TArg | Promise<TArg>) => R2;
 export function composeAsync<TArg, R1>(
-  f1: (a: TArg) => R1
-): (a: TArg) => R1;
+  f1: (a: Awaited<TArg>) => R1
+): (a: TArg | Promise<TArg>) => R1;
 
 /*
 Method: pipeAsync
@@ -5812,7 +5812,7 @@ Categories: Logic, Async
 // @SINGLE_MARKER
 export function pipeAsync<TArg, R1, R2, R3, R4, R5, R6, R7, TResult>(
   ...funcs: [
-      f1: (a: TArg) => R1,
+      f1: (a: Awaited<TArg>) => R1,
       f2: (a: Awaited<R1>) => R2,
       f3: (a: Awaited<R2>) => R3,
       f4: (a: Awaited<R3>) => R4,
@@ -5822,49 +5822,49 @@ export function pipeAsync<TArg, R1, R2, R3, R4, R5, R6, R7, TResult>(
       ...func: Array<(a: any) => any>,
       fnLast: (a: any) => TResult
   ]
-): (a: TArg) => TResult;  // fallback overload if number of piped functions greater than 7
+): (a: TArg | Promise<TArg>) => TResult;  // fallback overload if number of piped functions greater than 7
 export function pipeAsync<TArg, R1, R2, R3, R4, R5, R6, R7>(
-  f1: (a: TArg) => R1,
+  f1: (a: Awaited<TArg>) => R1,
   f2: (a: Awaited<R1>) => R2,
   f3: (a: Awaited<R2>) => R3,
   f4: (a: Awaited<R3>) => R4,
   f5: (a: Awaited<R4>) => R5,
   f6: (a: Awaited<R5>) => R6,
   f7: (a: Awaited<R6>) => R7
-): (a: TArg) => R7;
+): (a: TArg | Promise<TArg>) => R7;
 export function pipeAsync<TArg, R1, R2, R3, R4, R5, R6>(
-  f1: (a: TArg) => R1,
+  f1: (a: Awaited<TArg>) => R1,
   f2: (a: Awaited<R1>) => R2,
   f3: (a: Awaited<R2>) => R3,
   f4: (a: Awaited<R3>) => R4,
   f5: (a: Awaited<R4>) => R5,
   f6: (a: Awaited<R5>) => R6
-): (a: TArg) => R6;
+): (a: TArg | Promise<TArg>) => R6;
 export function pipeAsync<TArg, R1, R2, R3, R4, R5>(
-  f1: (a: TArg) => R1,
+  f1: (a: Awaited<TArg>) => R1,
   f2: (a: Awaited<R1>) => R2,
   f3: (a: Awaited<R2>) => R3,
   f4: (a: Awaited<R3>) => R4,
   f5: (a: Awaited<R4>) => R5
-): (a: TArg) => R5;
+): (a: TArg | Promise<TArg>) => R5;
 export function pipeAsync<TArg, R1, R2, R3, R4>(
-  f1: (a: TArg) => R1,
+  f1: (a: Awaited<TArg>) => R1,
   f2: (a: Awaited<R1>) => R2,
   f3: (a: Awaited<R2>) => R3,
   f4: (a: Awaited<R3>) => R4
-): (a: TArg) => R4;
+): (a: TArg | Promise<TArg>) => R4;
 export function pipeAsync<TArg, R1, R2, R3>(
-  f1: (a: TArg) => R1,
+  f1: (a: Awaited<TArg>) => R1,
   f2: (a: Awaited<R1>) => R2,
   f3: (a: Awaited<R2>) => R3
-): (a: TArg) => R3;
+): (a: TArg | Promise<TArg>) => R3;
 export function pipeAsync<TArg, R1, R2>(
-  f1: (a: TArg) => R1,
+  f1: (a: Awaited<TArg>) => R1,
   f2: (a: Awaited<R1>) => R2
-): (a: TArg) => R2;
+): (a: TArg | Promise<TArg>) => R2;
 export function pipeAsync<TArg, R1>(
-  f1: (a: TArg) => R1
-): (a: TArg) => R1;
+  f1: (a: Awaited<TArg>) => R1
+): (a: TArg | Promise<TArg>) => R1;
 
 /*
 Method: debounce

--- a/files/index.d.ts
+++ b/files/index.d.ts
@@ -5692,7 +5692,7 @@ export function anyType(targetType: RambdaTypes): (...input: any[]) => boolean;
 /*
 Method: composeAsync
 
-Explanation: Asynchronous version of `R.compose`
+Explanation: Asynchronous version of `R.compose`. `await`s the result of each function before passing it to the next. Returns a `Promise` of the result.
 
 Example:
 
@@ -5715,21 +5715,77 @@ const result = await R.composeAsync(
 
 Categories: Logic, Async
 
-Notes: It doesn't work with promises or function returning promises such as `const foo = input => new Promise(...)`.
-
 */
 // @SINGLE_MARKER
-export function composeAsync<Out>(
-  ...fns: (Async<any> | Func<any>)[]
-): (input: any) => Promise<Out>;
-export function composeAsync<Out>(
-  ...fns: (Async<any> | Func<any>)[]
-): (input: any) => Promise<Out>;
+export function composeAsync<TArg, R1, R2, R3, R4, R5, R6, R7, TResult>(
+  ...func: [
+      fnLast: (a: any) => TResult,
+      ...func: Array<(a: any) => any>,
+      f7: (a: Awaited<R6>) => R7,
+      f6: (a: Awaited<R5>) => R6,
+      f5: (a: Awaited<R4>) => R5,
+      f4: (a: Awaited<R3>) => R4,
+      f3: (a: Awaited<R2>) => R3,
+      f2: (a: Awaited<R1>) => R2,
+      f1: (a: TArg) => R1
+  ]
+): (a: TArg) => TResult; // fallback overload if number of composed functions greater than 7
+export function composeAsync<TArg, R1, R2, R3, R4, R5, R6, R7, TResult>(
+  f7: (a: Awaited<R6>) => R7,
+  f6: (a: Awaited<R5>) => R6,
+  f5: (a: Awaited<R4>) => R5,
+  f4: (a: Awaited<R3>) => R4,
+  f3: (a: Awaited<R2>) => R3,
+  f2: (a: Awaited<R1>) => R2,
+  f1: (a: TArg) => R1
+): (a: TArg) => R7;
+export function composeAsync<TArg, R1, R2, R3, R4, R5, R6, R7>(
+  f7: (a: Awaited<R6>) => R7,
+  f6: (a: Awaited<R5>) => R6,
+  f5: (a: Awaited<R4>) => R5,
+  f4: (a: Awaited<R3>) => R4,
+  f3: (a: Awaited<R2>) => R3,
+  f2: (a: Awaited<R1>) => R2,
+  f1: (a: TArg) => R1
+): (a: TArg) => R7;
+export function composeAsync<TArg, R1, R2, R3, R4, R5, R6>(
+  f6: (a: Awaited<R5>) => R6,
+  f5: (a: Awaited<R4>) => R5,
+  f4: (a: Awaited<R3>) => R4,
+  f3: (a: Awaited<R2>) => R3,
+  f2: (a: Awaited<R1>) => R2,
+  f1: (a: TArg) => R1
+): (a: TArg) => R6;
+export function composeAsync<TArg, R1, R2, R3, R4, R5>(
+  f5: (a: Awaited<R4>) => R5,
+  f4: (a: Awaited<R3>) => R4,
+  f3: (a: Awaited<R2>) => R3,
+  f2: (a: Awaited<R1>) => R2,
+  f1: (a: TArg) => R1
+): (a: TArg) => R5;
+export function composeAsync<TArg, R1, R2, R3, R4>(
+  f4: (a: Awaited<R3>) => R4,
+  f3: (a: Awaited<R2>) => R3,
+  f2: (a: Awaited<R1>) => R2,
+  f1: (a: TArg) => R1
+): (a: TArg) => R4;
+export function composeAsync<TArg, R1, R2, R3>(
+  f3: (a: Awaited<R2>) => R3,
+  f2: (a: Awaited<R1>) => R2,
+  f1: (a: TArg) => R1
+): (a: TArg) => R3;
+export function composeAsync<TArg, R1, R2>(
+  f2: (a: Awaited<R1>) => R2,
+  f1: (a: TArg) => R1
+): (a: TArg) => R2;
+export function composeAsync<TArg, R1>(
+  f1: (a: TArg) => R1
+): (a: TArg) => R1;
 
 /*
 Method: pipeAsync
 
-Explanation: Asynchronous version of `R.pipe`
+Explanation: Asynchronous version of `R.pipe`. `await`s the result of each function before passing it to the next. Returns a `Promise` of the result.
 
 Example:
 
@@ -5752,16 +5808,63 @@ const result = await R.pipeAsync(
 
 Categories: Logic, Async
 
-Notes: It doesn't work with promises or function returning promises such as `const foo = input => new Promise(...)`.
-
 */
 // @SINGLE_MARKER
-export function pipeAsync<Out>(
-  ...fns: (Async<any> | Func<any>)[]
-): (input: any) => Promise<Out>;
-export function pipeAsync<Out>(
-  ...fns: (Async<any> | Func<any>)[]
-): (input: any) => Promise<Out>;
+export function pipeAsync<TArg, R1, R2, R3, R4, R5, R6, R7, TResult>(
+  ...funcs: [
+      f1: (a: TArg) => R1,
+      f2: (a: Awaited<R1>) => R2,
+      f3: (a: Awaited<R2>) => R3,
+      f4: (a: Awaited<R3>) => R4,
+      f5: (a: Awaited<R4>) => R5,
+      f6: (a: Awaited<R5>) => R6,
+      f7: (a: Awaited<R6>) => R7,
+      ...func: Array<(a: any) => any>,
+      fnLast: (a: any) => TResult
+  ]
+): (a: TArg) => TResult;  // fallback overload if number of piped functions greater than 7
+export function pipeAsync<TArg, R1, R2, R3, R4, R5, R6, R7>(
+  f1: (a: TArg) => R1,
+  f2: (a: Awaited<R1>) => R2,
+  f3: (a: Awaited<R2>) => R3,
+  f4: (a: Awaited<R3>) => R4,
+  f5: (a: Awaited<R4>) => R5,
+  f6: (a: Awaited<R5>) => R6,
+  f7: (a: Awaited<R6>) => R7
+): (a: TArg) => R7;
+export function pipeAsync<TArg, R1, R2, R3, R4, R5, R6>(
+  f1: (a: TArg) => R1,
+  f2: (a: Awaited<R1>) => R2,
+  f3: (a: Awaited<R2>) => R3,
+  f4: (a: Awaited<R3>) => R4,
+  f5: (a: Awaited<R4>) => R5,
+  f6: (a: Awaited<R5>) => R6
+): (a: TArg) => R6;
+export function pipeAsync<TArg, R1, R2, R3, R4, R5>(
+  f1: (a: TArg) => R1,
+  f2: (a: Awaited<R1>) => R2,
+  f3: (a: Awaited<R2>) => R3,
+  f4: (a: Awaited<R3>) => R4,
+  f5: (a: Awaited<R4>) => R5
+): (a: TArg) => R5;
+export function pipeAsync<TArg, R1, R2, R3, R4>(
+  f1: (a: TArg) => R1,
+  f2: (a: Awaited<R1>) => R2,
+  f3: (a: Awaited<R2>) => R3,
+  f4: (a: Awaited<R3>) => R4
+): (a: TArg) => R4;
+export function pipeAsync<TArg, R1, R2, R3>(
+  f1: (a: TArg) => R1,
+  f2: (a: Awaited<R1>) => R2,
+  f3: (a: Awaited<R2>) => R3
+): (a: TArg) => R3;
+export function pipeAsync<TArg, R1, R2>(
+  f1: (a: TArg) => R1,
+  f2: (a: Awaited<R1>) => R2
+): (a: TArg) => R2;
+export function pipeAsync<TArg, R1>(
+  f1: (a: TArg) => R1
+): (a: TArg) => R1;
 
 /*
 Method: debounce
@@ -6537,7 +6640,7 @@ export function piped<A, B, C, D, E, F, G, H, I>(input: A, fn0: (x: A) => B, fn1
 /*
 Method: pipedAsync
 
-Explanation: It accepts input as first argument and series of functions as next arguments. It is same as `R.pipe` but with support for asynchronous functions.
+Explanation: It accepts input as first argument and series of functions as next arguments. It is same as `R.piped` but with support for asynchronous functions like `R.pipeAsync`.
 
 Example:
 
@@ -6559,14 +6662,16 @@ const result = await R.pipedAsync(
 
 Categories: Async
 
-Notes: Functions that return `Promise` will be handled as regular function not asynchronous. Such example is `const foo = input => new Promise(...)`.
-
 */
 // @SINGLE_MARKER
-export function pipedAsync<T>(
-  input: any,
-  ...fns: (Func<any> | Async<any>)[]
-): Promise<T>;
+export function pipedAsync<A, B>(input: A, fn0: (x: Awaited<A>) => B) : B;
+export function pipedAsync<A, B, C>(input: A, fn0: (x: Awaited<A>) => B, fn1: (x: Awaited<B>) => C) : C;
+export function pipedAsync<A, B, C, D>(input: A, fn0: (x: Awaited<A>) => B, fn1: (x: Awaited<B>) => C, fn2: (x: Awaited<C>) => D) : D;
+export function pipedAsync<A, B, C, D, E>(input: A, fn0: (x: Awaited<A>) => B, fn1: (x: Awaited<B>) => C, fn2: (x: Awaited<C>) => D, fn3: (x: Awaited<D>) => E) : E;
+export function pipedAsync<A, B, C, D, E, F>(input: A, fn0: (x: Awaited<A>) => B, fn1: (x: Awaited<B>) => C, fn2: (x: Awaited<C>) => D, fn3: (x: Awaited<D>) => E, fn4: (x: Awaited<E>) => F) : F;
+export function pipedAsync<A, B, C, D, E, F, G>(input: A, fn0: (x: Awaited<A>) => B, fn1: (x: Awaited<B>) => C, fn2: (x: Awaited<C>) => D, fn3: (x: Awaited<D>) => E, fn4: (x: Awaited<E>) => F, fn5: (x: Awaited<F>) => G) : G;
+export function pipedAsync<A, B, C, D, E, F, G, H>(input: A, fn0: (x: Awaited<A>) => B, fn1: (x: Awaited<B>) => C, fn2: (x: Awaited<C>) => D, fn3: (x: Awaited<D>) => E, fn4: (x: Awaited<E>) => F, fn5: (x: Awaited<F>) => G, fn6: (x: Awaited<G>) => H) : H;
+export function pipedAsync<A, B, C, D, E, F, G, H, I>(input: A, fn0: (x: Awaited<A>) => B, fn1: (x: Awaited<B>) => C, fn2: (x: Awaited<C>) => D, fn3: (x: Awaited<D>) => E, fn4: (x: Awaited<E>) => F, fn5: (x: Awaited<F>) => G, fn6: (x: Awaited<G>) => H, fn7: (x: Awaited<H>) => I) : I;
 
 /*
 Method: produce

--- a/source/composeAsync-spec.ts
+++ b/source/composeAsync-spec.ts
@@ -2,14 +2,28 @@ import {delay, composeAsync} from 'rambda'
 
 describe('R.composeAsync', () => {
   it('happy', async() => {
-    const result = await composeAsync<number>(
-      async x => {
-        await delay(100)
-        return x + 2
+    const result = await composeAsync(
+      // Notice the type parameter here. Because of the order of the functions,
+      // TypeScript won't infer the type of `x` from later functions, but using
+      // a type parameter we can leave it generic and properly compute the
+      // result type at the end.
+      <T>(x: T) => {
+        x // $ExpectType T
+        return Promise.resolve([x])
       },
-      x => x.length + 10
-    )([1, 2])
+      x => {
+        x // $ExpectType number
+        return new Promise<string>((resolve) => {
+          resolve(x.toString())
+        })
+      },
+      async (x: 4) => {
+        x // $ExpectType 4
+        await delay(100)
+        return x + 1
+      },
+    )(4)
 
-    result // $ExpectType number
+    result // $ExpectType string[]
   })
 })

--- a/source/composeAsync-spec.ts
+++ b/source/composeAsync-spec.ts
@@ -2,7 +2,7 @@ import {delay, composeAsync} from 'rambda'
 
 describe('R.composeAsync', () => {
   it('happy', async() => {
-    const result = await composeAsync(
+    const fn = composeAsync(
       // Notice the type parameter here. Because of the order of the functions,
       // TypeScript won't infer the type of `x` from later functions, but using
       // a type parameter we can leave it generic and properly compute the
@@ -22,8 +22,12 @@ describe('R.composeAsync', () => {
         await delay(100)
         return x + 1
       },
-    )(4)
+    )
 
-    result // $ExpectType string[]
+    const result1 = await fn(4)
+    const result2 = await fn(Promise.resolve(4))
+
+    result1 // $ExpectType string[]
+    result2 // $ExpectType string[]
   })
 })

--- a/source/composeAsync.js
+++ b/source/composeAsync.js
@@ -1,18 +1,5 @@
-import { type } from './type.js'
+import { pipeAsync } from './pipeAsync.js'
 
-export function composeAsync(...inputArguments){
-  return async function (startArgument){
-    let argumentsToPass = startArgument
-
-    while (inputArguments.length !== 0){
-      const fn = inputArguments.pop()
-
-      argumentsToPass = fn(argumentsToPass)
-      if (type(argumentsToPass) === 'Promise'){
-        argumentsToPass = await argumentsToPass
-      }
-    }
-
-    return argumentsToPass
-  }
+export function composeAsync(...fnList){
+  return pipeAsync(...fnList.reverse())
 }

--- a/source/mapToObjectAsync-spec.ts
+++ b/source/mapToObjectAsync-spec.ts
@@ -23,8 +23,8 @@ describe('R.mapToObjectAsync', () => {
     result // $ExpectType Output
   })
   it('with R.composeAsync', async() => {
-    const result = await composeAsync<Output>(
-      mapToObjectAsync(fn),
+    const result = await composeAsync(
+      mapToObjectAsync<number, Output>(fn),
       (x: number[]) => x.filter((xx: number) => xx > 2)
     )(list)
 

--- a/source/pipeAsync-spec.ts
+++ b/source/pipeAsync-spec.ts
@@ -2,7 +2,7 @@ import {delay, pipeAsync} from 'rambda'
 
 describe('R.pipeAsync', () => {
   it('happy', async() => {
-    const result = await pipeAsync(
+    const fn = pipeAsync(
       async (x: 4) => {
         x // $ExpectType 4
         await delay(100)
@@ -18,8 +18,12 @@ describe('R.pipeAsync', () => {
         x // $ExpectType string
         return Promise.resolve([x])
       }
-    )(4)
+    )
 
-    result // $ExpectType string[]
+    const result1 = await fn(4)
+    const result2 = await fn(Promise.resolve(4))
+
+    result1 // $ExpectType string[]
+    result2 // $ExpectType string[]
   })
 })

--- a/source/pipeAsync-spec.ts
+++ b/source/pipeAsync-spec.ts
@@ -2,14 +2,24 @@ import {delay, pipeAsync} from 'rambda'
 
 describe('R.pipeAsync', () => {
   it('happy', async() => {
-    const result = await pipeAsync<number>(
-      async x => {
+    const result = await pipeAsync(
+      async (x: 4) => {
+        x // $ExpectType 4
         await delay(100)
-        return x + 2
+        return x + 1
       },
-      x => x.length + 10
-    )([1, 2])
+      x => {
+        x // $ExpectType number
+        return new Promise<string>((resolve) => {
+          resolve(x.toString())
+        })
+      },
+      x => {
+        x // $ExpectType string
+        return Promise.resolve([x])
+      }
+    )(4)
 
-    result // $ExpectType number
+    result // $ExpectType string[]
   })
 })

--- a/source/pipeAsync.js
+++ b/source/pipeAsync.js
@@ -1,18 +1,7 @@
-import { type } from './type.js'
+import { reduce } from "./reduce";
 
-export function pipeAsync(...inputArguments){
-  return async function (startArgument){
-    let argumentsToPass = startArgument
-
-    while (inputArguments.length !== 0){
-      const fn = inputArguments.shift()
-
-      argumentsToPass = fn(argumentsToPass)
-      if (type(argumentsToPass) === 'Promise'){
-        argumentsToPass = await argumentsToPass
-      }
-    }
-
-    return argumentsToPass
+export function pipeAsync(...fnList){
+  return function (startArgument){
+    return reduce(async (value, fn) => fn(await value), startArgument, fnList)
   }
 }

--- a/source/pipeAsync.spec.js
+++ b/source/pipeAsync.spec.js
@@ -1,6 +1,4 @@
 import { delay } from './delay.js'
-import { equals } from './equals.js'
-import { map } from './map.js'
 import { pipeAsync } from './pipeAsync.js'
 
 async function identity(x){
@@ -31,7 +29,7 @@ const delayFn = ms =>
     resolve(ms + 1)
   })
 
-test('with function returning promise', async () => {
+test.only('with function returning promise', async () => {
   const result = await pipeAsync(
     x => x,
     x => x + 1,

--- a/source/pipedAsync-spec.ts
+++ b/source/pipedAsync-spec.ts
@@ -2,18 +2,25 @@ import {pipedAsync, delay} from 'rambda'
 
 describe('R.pipedAsync', () => {
   it('happy', async() => {
-    const result = await pipedAsync<number>(
-      4,
+    const result = await pipedAsync(
+      4 as const,
       async x => {
+        x // $ExpectType 4
         await delay(100)
         return x + 1
       },
-      async x => {
-        await delay(100)
-        return x + 10
+      x => {
+        x // $ExpectType number
+        return new Promise<string>((resolve) => {
+          resolve(x.toString())
+        })
+      },
+      x => {
+        x // $ExpectType string
+        return Promise.resolve([x])
       }
     )
 
-    result // $ExpectType number
+    result // $ExpectType string[]
   })
 })

--- a/source/pipedAsync.js
+++ b/source/pipedAsync.js
@@ -1,20 +1,5 @@
-import { type } from './type.js'
+import { pipeAsync } from "./pipeAsync";
 
-export async function pipedAsync(...inputs){
-  const [ input, ...fnList ] = inputs
-
-  let argumentsToPass = input
-
-  while (fnList.length !== 0){
-    const fn = fnList.shift()
-    const typeFn = type(fn)
-
-    if (typeFn === 'Promise'){
-      argumentsToPass = await fn(argumentsToPass)
-    } else {
-      argumentsToPass = fn(argumentsToPass)
-    }
-  }
-
-  return argumentsToPass
+export function pipedAsync(input, ...fnList) {
+  return pipeAsync(...fnList)(input)
 }

--- a/source/pipedAsync.spec.js
+++ b/source/pipedAsync.spec.js
@@ -2,13 +2,13 @@ import { add } from './add.js'
 import { delay } from './delay.js'
 import { pipedAsync } from './pipedAsync.js'
 
-const fn1 = async x => {
-  await delay(100)
-
-  return x + 2
+const fn1 = x => {
+  return new Promise((resolve) => {
+    resolve(x + 2)
+  })
 }
 const fn2 = async x => {
-  await delay(100)
+  await delay(1)
 
   return x + 3
 }


### PR DESCRIPTION
This one's a bit beefier than the PRs I've been posting so far. There are a few pieces here that could be accepted or rejected separately, but they all seemed to go together, so I went for the whole thing. Let me know if you'd like me to split this up or resubmit with other changes.

The main goal here was to use `R.pipedAsync`. First, I had a function which returned a constructed `Promise`, which wasn't supported. Then, I noticed that the types for `R.pipedAsync` (as well as `R.composeAsync` and `R.pipeAsync`) weren't really checking types the way their synchronous equivalents were: they were just accepting a type parameter to assert at the end of the chain. While I was in there, I simplified the functions in terms of one another, but they can work just as well in a more explicit form if you prefer it that way.

There are two minor breaking changes, as described below. One is likely not to come up; the other is easy to adjust code for.

* **`R.pipedAsync` works with `new Promise()`:** I've made `R.pipedAsync` `await` every returned value, so it doesn't need to inspect the function's `.toString()` to determine if it should consider it async. `await`ing a non-thenable simply returns the value, so this should be the expected behavior. (Incidentally, the docs make it sound like this issue applied to `R.composeAsync` and `R.pipeAsync` as well, but it didn't—maybe that was changed at some point without updating the docs?) _**BREAKING:**_ Code which used non `async` functions returning thenables will now start `await`ing those values instead of passing them on directly. This is unlikely to be something anyone has been expecting to work.

* **`R.composeAsync`, `R.pipeAsync`, and `R.pipedAsync` are type-validated:** I've used types akin to these functions' synchronous counterparts to follow the types through the chain. (Note: It _is_ possible to write more thorough types for composition, though [it gets bulky](https://github.com/millsp/medium/blob/master/types-curry-ramda/src/bonus.ts). I'll leave you that link in case you're interested at some point.) _**BREAKING:**_ As demonstrated in `mapToObjectAsync-spec.ts`, the type parameter signature for these has changed, matching the shape of the synchronous versions. Unfortunately, this is likely to come up for many users of these functions, since they previously depended on this parameter for any type support. Luckily, the change is easy: client code should in many cases now be able to remove the type argument and let TS infer meaningful types, and where client code would prefer to still assert the type of the output, it can use an actual type assertion with `as SomeType` at the end.

* **`R.composeAsync` and `R.pipedAsync` are built on `R.pipeAsync`:** This simply refactors these functions so as not to re-write the looping logic in three places. No behavior should be changed.

* **`R.pipeAsync` is built on `R.reduce`:** Similarly, this is just a refactoring. No behavior should be changed.