### PR TITLE
`R.prepend`/`R.append` fns accept broader types

### DIFF
--- a/files/index.d.ts
+++ b/files/index.d.ts
@@ -115,6 +115,9 @@ type RegExpReplacerFn =
   | ((m: string, p1: string, p2: string, p3: string, p4: string, p5: string, p6: string, p7: string, p8: string, p9: string, offset: number, s: string, groups?: Record<string, string>) => string)
 type RegExpReplacer = string | RegExpReplacerFn
 
+/** `TSuper`, whenever `TSuper` is a supertype of `TSub`; otherwise `never`. */
+type AsSuperType<TSub, TSuper> = (TSub extends TSuper ? TSuper : never);
+
 // RAMBDAX INTERFACES
 // ============================================
 type Func<T> = (input: any) => T;
@@ -415,8 +418,8 @@ Notes:
 
 */
 // @SINGLE_MARKER
-export function append<T>(x: T, list: T[]): T[];
-export function append<T>(x: T): (list: T[]) => T[];
+export function append<TElement>(x: TElement, input: TElement[]): TElement[];
+export function append<TNewElement>(x: TNewElement): <TElement>(input: AsSuperType<TNewElement, TElement>[]) => TElement[];
 
 /*
 Method: applySpec
@@ -3239,8 +3242,8 @@ Notes:
 
 */
 // @SINGLE_MARKER
-export function prepend<T>(x: T, input: T[]): T[];
-export function prepend<T>(x: T): (input: T[]) => T[];
+export function prepend<TElement>(x: TElement, input: TElement[]): TElement[];
+export function prepend<TNewElement>(x: TNewElement): <TElement>(input: AsSuperType<TNewElement, TElement>[]) => TElement[];
 
 /*
 Method: product

--- a/source/append-spec.ts
+++ b/source/append-spec.ts
@@ -1,18 +1,55 @@
 import {append} from 'rambda'
 
-const list = [1, 2, 3]
+const listOfNumbers = [1, 2, 3]
+const listOfNumbersAndStrings = [1, "b", 3]
 
 describe('R.append', () => {
-  it('happy', () => {
-    const result = append(4, list)
-    result // $ExpectType number[]
-  })
+  describe('with the same primitive type as the array\'s elements', () => {
+    it('uncurried', () => {
+      // @ts-expect-error
+      append("d", listOfNumbers)
+      const result = append(4, listOfNumbers)
+      result // $ExpectType number[]
+    })
 
-  it('curried', () => {
-    const curried = append(4)
-    curried // $ExpectType (list: number[]) => number[]
+    it('curried', () => {
+      // @ts-expect-error
+      append("d")(listOfNumbers)
+      const result = append(4)(listOfNumbers)
+      result // $ExpectType number[]
+    })
+  });
 
-    const result = curried(list)
-    result // $ExpectType number[]
-  })
+  describe('with a subtype of the array\'s elements', () => {
+    it('uncurried', () => {
+      // @ts-expect-error
+      append(true, listOfNumbersAndStrings)
+      const result = append(4, listOfNumbersAndStrings)
+      result // $ExpectType (string | number)[]
+    })
+
+    it('curried', () => {
+      // @ts-expect-error
+      append(true)(listOfNumbersAndStrings)
+      const result = append(4)(listOfNumbersAndStrings)
+      result // $ExpectType (string | number)[]
+    })
+  });
+
+  describe('expanding the type of the array\'s elements', () => {
+    it('uncurried', () => {
+      // @ts-expect-error
+      append("d", listOfNumbers)
+      const result = append<string | number>("d", listOfNumbers)
+      result // $ExpectType (string | number)[]
+    })
+
+    it('curried', () => {
+      // @ts-expect-error
+      append("d")(listOfNumbers)
+      const appendD = append("d");
+      const result = appendD<string | number>(listOfNumbers)
+      result // $ExpectType (string | number)[]
+    })
+  });
 })

--- a/source/prepend-spec.ts
+++ b/source/prepend-spec.ts
@@ -1,16 +1,55 @@
 import {prepend} from 'rambda'
 
-const list = [1, 2, 3]
+const listOfNumbers = [1, 2, 3]
+const listOfNumbersAndStrings = [1, "b", 3]
 
 describe('R.prepend', () => {
-  it('happy', () => {
-    const result = prepend(4, list)
+  describe('with the same primitive type as the array\'s elements', () => {
+    it('uncurried', () => {
+      // @ts-expect-error
+      prepend("d", listOfNumbers)
+      const result = prepend(4, listOfNumbers)
+      result // $ExpectType number[]
+    })
 
-    result // $ExpectType number[]
-  })
-  it('curried', () => {
-    const result = prepend(4)(list)
+    it('curried', () => {
+      // @ts-expect-error
+      prepend("d")(listOfNumbers)
+      const result = prepend(4)(listOfNumbers)
+      result // $ExpectType number[]
+    })
+  });
 
-    result // $ExpectType number[]
-  })
+  describe('with a subtype of the array\'s elements', () => {
+    it('uncurried', () => {
+      // @ts-expect-error
+      prepend(true, listOfNumbersAndStrings)
+      const result = prepend(4, listOfNumbersAndStrings)
+      result // $ExpectType (string | number)[]
+    })
+
+    it('curried', () => {
+      // @ts-expect-error
+      prepend(true)(listOfNumbersAndStrings)
+      const result = prepend(4)(listOfNumbersAndStrings)
+      result // $ExpectType (string | number)[]
+    })
+  });
+
+  describe('expanding the type of the array\'s elements', () => {
+    it('uncurried', () => {
+      // @ts-expect-error
+      prepend("d", listOfNumbers)
+      const result = prepend<string | number>("d", listOfNumbers)
+      result // $ExpectType (string | number)[]
+    })
+
+    it('curried', () => {
+      // @ts-expect-error
+      prepend("d")(listOfNumbers)
+      const prependD = prepend("d");
+      const result = prependD<string | number>(listOfNumbers)
+      result // $ExpectType (string | number)[]
+    })
+  });
 })

--- a/source/zipObj-spec.ts
+++ b/source/zipObj-spec.ts
@@ -4,7 +4,7 @@ describe('R.zipObj', () => {
   it('happy', () => {
     // this is wrong since 24.10.2020 `@types/ramda` changes
     const result = zipObj(['a', 'b', 'c', 'd'], [1, 2, 3])
-    result // $ExpectType { b: number; a: number; c: number; d: number; }
+    result // $ExpectType { b: number; d: number; a: number; c: number; }
   })
   it('imported from @types/ramda', () => {
     const result = zipObj(['a', 'b', 'c'], [1, 2, 3])


### PR DESCRIPTION
Before, `R.prepend(4)` or `R.append(4)` would produce a function which could only be applied to a `number[]`. However, you may well want to append a `4` to an array whose elements can be `number`s or other things, such as a `(string | number)[]`. This commit improves the types to accept such arrays.

You may also have an array of a more specific type (such as `number[]`) and wish to use `R.prepend`/`R.append` to expand the type. Because it's usually a mistake, `append("d")(listOfNumbers)` will cause a type error; however, explicitly calling `append("d")<string | number>(listOfNumbers)` will give you a `(string | number)[]`.