### PR TITLE
`R.keys` always returns strings

### DIFF
--- a/files/index.d.ts
+++ b/files/index.d.ts
@@ -1864,7 +1864,7 @@ Notes:
 
 */
 // @SINGLE_MARKER
-export function keys<T extends object>(x: T): (keyof T)[];
+export function keys<T extends object>(x: T): (keyof T & string)[];
 export function keys<T>(x: T): string[];
 
 /*

--- a/source/keys-spec.ts
+++ b/source/keys-spec.ts
@@ -2,9 +2,18 @@ import {keys} from 'rambda'
 
 const obj = {a: 1, b: 2}
 
+interface Generic {
+  [key: string]: string;
+}
+
 describe('R.keys', () => {
-  it('happy', () => {
+  it('for a known object type', () => {
     const result = keys(obj)
     result // $ExpectType ("b" | "a")[]
+  })
+
+  it('for a generic object type', () => {
+    const result = keys({} as Generic)
+    result // $ExpectType string[]
   })
 })


### PR DESCRIPTION
Surprisingly, `keyof` a type with a string index signature is `string | number`, because:

> JavaScript object keys are always coerced to a string, so `obj[0]` is always the same as `obj["0"]`.

https://www.typescriptlang.org/docs/handbook/2/keyof-types.html

However, `Object.keys` will always return an array of strings, so we can restrict this to types which are also `string` and get the right type.