### PR TITLE
Fix `R.partial`

### DIFF
--- a/files/index.d.ts
+++ b/files/index.d.ts
@@ -2798,13 +2798,32 @@ Notes: Rambda's partial doesn't need the input arguments to be wrapped as array.
 
 */
 // @SINGLE_MARKER
-export function partial<V0, V1, T>(fn: (x0: V0, x1: V1) => T, args: [V0]): (x1: V1) => T;
-export function partial<V0, V1, V2, T>(fn: (x0: V0, x1: V1, x2: V2) => T, args: [V0, V1]): (x2: V2) => T;
-export function partial<V0, V1, V2, T>(fn: (x0: V0, x1: V1, x2: V2) => T, args: [V0]): (x1: V1, x2: V2) => T;
-export function partial<V0, V1, V2, V3, T>(fn: (x0: V0, x1: V1, x2: V2, x3: V3) => T, args: [V0, V1, V2]): (x2: V3) => T;
-export function partial<V0, V1, V2, V3, T>(fn: (x0: V0, x1: V1, x2: V2, x3: V3) => T, args: [V0, V1]): (x2: V2, x3: V3) => T;
-export function partial<V0, V1, V2, V3, T>(fn: (x0: V0, x1: V1, x2: V2, x3: V3) => T, args: [V0]): (x1: V1, x2: V2, x3: V3) => T;
-export function partial<T>(fn: (...a: any[]) => T, args: any[]): (...x: any[]) => T;
+export function partial<
+  Args extends unknown[],
+  ArgsGiven extends [...Partial<Args>],
+  R
+>(
+  fn: (...args: Args) => R,
+  ...args: ArgsGiven
+): Args extends [...{[K in keyof ArgsGiven]: Args[K]}, ...infer ArgsRemaining]
+  ? ArgsRemaining extends []
+    ? R
+    : (...args: ArgsRemaining) => R
+  : never;
+
+export function partial<
+  Args extends readonly unknown[],
+  ArgsGiven extends [...Partial<Args>],
+  R
+>(
+  fn: (...args: Args) => R,
+  args: ArgsGiven
+): Args extends [...{[K in keyof ArgsGiven]: Args[K]}, ...infer ArgsRemaining]
+  ? ArgsRemaining extends []
+    ? R
+    : (...args: ArgsRemaining) => R
+  : never;
+
 
 /*
 Method: partition

--- a/source/partial-spec.ts
+++ b/source/partial-spec.ts
@@ -2,18 +2,47 @@ import {partial} from 'rambda'
 
 describe('R.partial', () => {
   it('happy', () => {
-    function greet(
-      salutation: string,
-      title: string,
-      firstName: string,
-      lastName: string
+    function fn(
+      aString: string,
+      aNumber: number,
+      aBoolean: boolean,
+      aNull: null
     ) {
-      return `${salutation}, ${title} ${firstName} ${lastName}!`
+      return { aString, aNumber, aBoolean, aNull }
     }
 
-    const sayHello = partial(greet, ['Hello'])
-    const sayHelloToMs = partial(sayHello, ['Ms.'])
-    const result = sayHelloToMs('Jane', 'Jones')
-    result // $ExpectType string
+    // @ts-expect-error
+    partial(fn, 1);
+
+    const fn1 = partial(fn, 'a')
+
+    // @ts-expect-error
+    partial(fn1, 'b');
+
+    const fn2 = partial(fn1, 2)
+    const result = fn2(true, null)
+    result // $ExpectType { aString: string; aNumber: number; aBoolean: boolean; aNull: null; }
   })
-})
+
+  it('ramda', () => {
+    function fn(
+      aString: string,
+      aNumber: number,
+      aBoolean: boolean,
+      aNull: null
+    ) {
+      return { aString, aNumber, aBoolean, aNull }
+    }
+
+    // @ts-expect-error
+    partial(fn, 1);
+
+    const fn1 = partial(fn, ['a'])
+
+    // @ts-expect-error
+    partial(fn1, ['b']);
+
+    const fn2 = partial(fn1, [2])
+    const result = fn2(true, null)
+    result // $ExpectType { aString: string; aNumber: number; aBoolean: boolean; aNull: null; }
+  })})

--- a/source/partial.js
+++ b/source/partial.js
@@ -1,11 +1,17 @@
+import { isArray } from './_internals/isArray.js'
+
 export function partial(fn, ...args){
   const len = fn.length
 
+  // If a single array argument is given, those are the args (a la Ramda).
+  // Otherwise, the variadic arguments are the args.
+  const argList = args.length === 1 && isArray(args[0]) ? args[0] : args
+
   return (...rest) => {
-    if (args.length + rest.length >= len){
-      return fn(...args, ...rest)
+    if (argList.length + rest.length >= len){
+      return fn(...argList, ...rest)
     }
 
-    return partial(fn, ...[ ...args, ...rest ])
+    return partial(fn, ...[ ...argList, ...rest ])
   }
 }

--- a/source/partial.spec.js
+++ b/source/partial.spec.js
@@ -4,7 +4,7 @@ import { type } from './type.js'
 const greet = (
   salutation, title, firstName, lastName
 ) =>
-  salutation + ', ' + title + ' ' + firstName + ' ' + lastName + '!'
+  [salutation, title, firstName, lastName]
 
 test('happy', () => {
   const canPassAnyNumberOfArguments = partial(
@@ -16,8 +16,8 @@ test('happy', () => {
 
   expect(type(fn)).toBe('Function')
 
-  expect(fn('bar')).toBe('Hello, Ms. foo bar!')
-  expect(sayHelloRamda('foo', 'bar')).toBe('Hello, Ms. foo bar!')
+  expect(fn('bar')).toStrictEqual(['Hello', 'Ms.', 'foo', 'bar'])
+  expect(sayHelloRamda('foo', 'bar')).toStrictEqual(['Hello', 'Ms.', 'foo', 'bar'])
 })
 
 test('extra arguments are ignored', () => {
@@ -30,7 +30,7 @@ test('extra arguments are ignored', () => {
 
   expect(fn(
     'bar', 1, 2
-  )).toBe('Hello, Ms. foo bar!')
+  )).toStrictEqual(['Hello', 'Ms.', 'foo', 'bar'])
 })
 
 test('when array is input', () => {
@@ -58,5 +58,5 @@ test('ramda spec', () => {
   const sayHello = partial(greet, 'Hello')
   const sayHelloToMs = partial(sayHello, 'Ms.')
 
-  expect(sayHelloToMs('Jane', 'Jones')).toBe('Hello, Ms. Jane Jones!')
+  expect(sayHelloToMs('Jane', 'Jones')).toStrictEqual(['Hello', 'Ms.', 'Jane', 'Jones'])
 })


### PR DESCRIPTION
* **Implementation:** The documentation states that Rambda's partial can either take arguments as an array (like Ramda) or as variadic arguments. However, the implementation didn't actually support the Ramda style. Now it does.

* **Tests:** The tests made it look as if the Ramda style worked. However, this was only because we were concatenating the results with `+`, and `"a" + ["b"] === "a" + "b"`. The tests now truly validate that Ramda style works.

* **Types:** Meanwhile, the types *only* permitted the Ramda style, even though that style didn't work. I've replaced those with a new type which a) supports the variadic style, and b) doesn't rely on a finite set of overrides. There are now only two overrides: one for the variadic style and one for the Ramda style.