### PR TITLE
corrected implementation of unless function

### DIFF
--- a/src/unless.js
+++ b/src/unless.js
@@ -1,7 +1,11 @@
-export function unless(predicate, whenFalse){
-  if (arguments.length === 1){
-    return _whenFalse => unless(predicate, _whenFalse)
-  }
+import { curry } from './curry.js'
 
-  return input => predicate(input) ? input : whenFalse(input)
+function unlessFn(
+  predicate, whenFalseFn, input
+){
+  if (predicate(input)) return input
+
+  return whenFalseFn(input)
 }
+
+export const unless = curry(unlessFn)


### PR DESCRIPTION
This is a type definition from `node_modules/rambda/index.d.ts`
```
export function unless<T, U>(predicate: (x: T) => boolean, whenFalseFn: (x: T) => U, x: T): T | U;
export function unless<T, U>(predicate: (x: T) => boolean, whenFalseFn: (x: T) => U): (x: T) => T | U;
export function unless<T>(predicate: (x: T) => boolean, whenFalseFn: (x: T) => T, x: T): T;
export function unless<T>(predicate: (x: T) => boolean, whenFalseFn: (x: T) => T): (x: T) => T;
```
This is implementation from `node_modules/rambda/src/unless.js`
```
export function unless(predicate, whenFalse){
  if (arguments.length === 1){
    return _whenFalse => unless(predicate, _whenFalse)
  }

  return input => predicate(input) ? input : whenFalse(input)
}
```
The problem that this incorrectly works with 3 parameters.
Example:
```
export const getCurrentURL = () => unless(startsWith('/'), concat('/'), window.location.pathname)
```
This should return the string.
But it returns the function: `input => predicate(input) ? input : whenFalse(input)`
Which is not surprising based on the implementation

The `when` function works great
An example of correct implementation based on the `when` function:
```
import { curry } from './curry.js'

function unlessFn(predicate, whenFalseFn, input){
  if (predicate(input)) return input

  return whenFalseFn(input)
}

export const unless = curry(unlessFn)
```