### PR TITLE
perf: path()

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -10,7 +10,6 @@ export function pathFn(pathInput, obj){
     if (willReturn === null || willReturn === undefined){
       return undefined
     }
-    if (willReturn[ pathArrValue[ counter ] ] === null) return undefined
 
     willReturn = willReturn[ pathArrValue[ counter ] ]
     counter++


### PR DESCRIPTION
If I'm not mistaken, this check is redundant with the one above.